### PR TITLE
Global config and command

### DIFF
--- a/lib/ProjectConfig.ts
+++ b/lib/ProjectConfig.ts
@@ -6,8 +6,8 @@ export class ProjectConfig {
 
 	public static configFile: string = "ignite-ui-cli.json";
 
-	/** TODO: Use this to check for existing local project instead of `getConfig` */
-	public static localConfigFile(): boolean {
+	/** Returns true if there's a CLI config file in the current working directory */
+	public static hasLocalConfig(): boolean {
 		const filePath = path.join(process.cwd(), this.configFile);
 		return fs.existsSync(filePath);
 	}

--- a/lib/ProjectConfig.ts
+++ b/lib/ProjectConfig.ts
@@ -6,6 +6,7 @@ import { Util } from "./Util";
 export class ProjectConfig {
 
 	public static configFile: string = "ignite-ui-cli.json";
+	public static readonly defaults: Config = require("./config/defaults.json");
 
 	/** Returns true if there's a CLI config file in the current working directory */
 	public static hasLocalConfig(): boolean {
@@ -19,13 +20,15 @@ export class ProjectConfig {
 	 */
 	public static getConfig(global: boolean = false): Config {
 		const filePath = path.join(process.cwd(), this.configFile);
-		const config = this.globalDefaults();
+		const config = {};
+
+		Util.merge(config, this.defaults);
+		Util.merge(config, this.globalConfig());
 
 		if (!global) {
-			const localConfig = this.localConfig();
-			Util.merge(config, localConfig);
+			Util.merge(config, this.localConfig());
 		}
-		return config;
+		return config as Config;
 	}
 
 	/**
@@ -65,14 +68,5 @@ export class ProjectConfig {
 			globalConfig = require(globalConfigPath);
 		}
 		return globalConfig as Config;
-	}
-
-	/** Get effective global configuration defaults */
-	private static globalDefaults(): Config {
-		const defaults: Config = require("./config/defaults.json");
-		const globalConfig = this.globalConfig();
-
-		Util.merge(defaults, globalConfig);
-		return defaults;
 	}
 }

--- a/lib/ProjectConfig.ts
+++ b/lib/ProjectConfig.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
+import { Util } from "./Util";
 
 export class ProjectConfig {
 
@@ -18,20 +19,28 @@ export class ProjectConfig {
 	 */
 	public static getConfig(global: boolean = false): Config {
 		const filePath = path.join(process.cwd(), this.configFile);
-		let config = this.globalDefaults();
+		const config = this.globalDefaults();
 
 		if (!global) {
 			const localConfig = this.localConfig();
-			config = Object.assign(config, localConfig);
+			Util.merge(config, localConfig);
 		}
 		return config;
 	}
+
+	/**
+	 * Write a configuration file (either local or global) with given `Config` object.
+	 * Will create or overwrite.
+	 * @param config Config object to set
+	 * @param global Set global values instead
+	 */
 	public static setConfig(config: Config, global: boolean = false) {
 		const basePath = global ? os.homedir() : process.cwd();
 		const filePath = path.join(basePath, this.configFile);
 		fs.writeJsonSync(filePath, config, { spaces: 4 });
 	}
 
+	/*** Get local configuration only */
 	public static localConfig(): Config {
 		const filePath = path.join(process.cwd(), this.configFile);
 		let localConfig = {};
@@ -47,6 +56,7 @@ export class ProjectConfig {
 		return localConfig as Config;
 	}
 
+	/*** Get global configuration only */
 	public static globalConfig(): Config {
 		const globalConfigPath = path.join(os.homedir(), this.configFile);
 		let globalConfig = {};
@@ -57,12 +67,12 @@ export class ProjectConfig {
 		return globalConfig as Config;
 	}
 
+	/** Get effective global configuration defaults */
 	private static globalDefaults(): Config {
-		let defaults: Config = require("./config/defaults.json");
+		const defaults: Config = require("./config/defaults.json");
 		const globalConfig = this.globalConfig();
 
-		// TODO: `Object.assign` doesn't do deep extend, nested object properties override!
-		defaults = Object.assign(defaults, globalConfig);
+		Util.merge(defaults, globalConfig);
 		return defaults;
 	}
 }

--- a/lib/ProjectConfig.ts
+++ b/lib/ProjectConfig.ts
@@ -1,26 +1,54 @@
 import * as fs from "fs-extra";
+import * as os from "os";
 import * as path from "path";
 
 export class ProjectConfig {
 
 	public static configFile: string = "ignite-ui-cli.json";
 
-	public static getConfig(): Config {
+	/** TODO: Use this to check for existing local project instead of `getConfig` */
+	public static localConfigFile(): boolean {
 		const filePath = path.join(process.cwd(), this.configFile);
-		if (fs.existsSync(filePath)) {
+		return fs.existsSync(filePath);
+	}
+
+	public static getConfig(global: boolean = false): Config {
+		const filePath = path.join(process.cwd(), this.configFile);
+		let config = this.globalDefaults();
+
+		if (!global && fs.existsSync(filePath)) {
 			try {
-				return JSON.parse(fs.readFileSync(filePath, "utf8")) as Config;
+				const localConfig = JSON.parse(fs.readFileSync(filePath, "utf8")) as Config;
+				config = Object.assign(config, localConfig);
 			} catch (error) {
 				throw new Error(`The ${this.configFile} file is not parsed correctly. ` +
 					`The following error has occurred: ${error.message}`);
 			}
 		}
-		return null;
+		return config;
 	}
-	public static setConfig(config: Config) {
-		const filePath = path.join(process.cwd(), this.configFile);
-		if (fs.existsSync(filePath)) {
-			fs.writeJsonSync(filePath, config, { spaces: 4 });
+	public static setConfig(config: Config, global: boolean = false) {
+		const basePath = global ? os.homedir() : process.cwd();
+		const filePath = path.join(basePath, this.configFile);
+		fs.writeJsonSync(filePath, config, { spaces: 4 });
+	}
+
+	public static globalConfig(): Config {
+		const globalConfigPath = path.join(os.homedir(), this.configFile);
+		let globalConfig = {};
+
+		if (fs.existsSync(globalConfigPath)) {
+			globalConfig = require(globalConfigPath);
 		}
+		return globalConfig as Config;
+	}
+
+	private static globalDefaults(): Config {
+		let defaults: Config = require("./config/defaults.json");
+		const globalConfig = this.globalConfig();
+
+		// TODO: `Object.assign` doesn't do deep extend, nested object properties override!
+		defaults = Object.assign(defaults, globalConfig);
+		return defaults;
 	}
 }

--- a/lib/PromptSession.ts
+++ b/lib/PromptSession.ts
@@ -22,7 +22,7 @@ export class PromptSession {
 		add.templateManager = this.templateManager;
 
 		// tslint:disable:object-literal-sort-keys
-		if (config != null && !config.project.isShowcase) {
+		if (ProjectConfig.hasLocalConfig() && !config.project.isShowcase) {
 			projLibrary = this.templateManager.getProjectLibrary(config.project.framework, config.project.projectType);
 			await this.chooseActionLoop(projLibrary, config.project.theme);
 		} else {

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -263,6 +263,17 @@ class Util {
 			}
 		}
 	}
+
+	private static propertyByPath(object: any, propPath: string) {
+		if (!propPath) {
+			return object;
+		}
+		const pathParts = propPath.split(".");
+		const currentProp = pathParts.shift();
+		if (currentProp in object) {
+			return this.propertyByPath(object[currentProp], pathParts.join("."));
+		}
+	}
 }
 
 export { Util };

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -237,6 +237,32 @@ class Util {
 	public static isAlphanumericExt(name: string) {
 		return /^[\sa-zA-Z][\w\s\-]+$/.test(name);
 	}
+
+	/**
+	 * Simple object merge - deep nested objects and arrays (of primitive values only)
+	 * @param target Object to merge values into
+	 * @param source Object to merge values from
+	 */
+	public static merge(target: any, source: any) {
+		for (const key of Object.keys(source)) {
+			if (!target.hasOwnProperty(key) || typeof source[key] !== "object") {
+				// primitive/new value:
+				target[key] = source[key];
+			} else if (Array.isArray(source[key])) {
+				// skip array merge on target type mismatch:
+				if (!Array.isArray(target[key])) {
+					continue;
+				}
+				for (const item of source[key]) {
+					if (target[key].indexOf(item) === -1) {
+						target[key].push(item);
+					}
+				}
+			} else {
+				this.merge(target[key], source[key]);
+			}
+		}
+	}
 }
 
 export { Util };

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -3,6 +3,7 @@ import * as inquirer from "inquirer";
 import * as yargs from "yargs";
 import { default as add } from "./commands/add";
 import { default as build } from "./commands/build";
+import { default as config } from "./commands/config";
 import { default as newCommand } from "./commands/new";
 import { default as quickstart } from "./commands/quickstart";
 import { default as start } from "./commands/start";
@@ -28,6 +29,7 @@ export async function run(args = null) {
 	.command(start)
 	.command(newCommand)
 	.command(build)
+	.command(config)
 	.command(test)
 	.command(add)
 	.options({
@@ -65,6 +67,8 @@ export async function run(args = null) {
 			break;
 		case "build":
 			await build.execute(argv);
+			break;
+		case "config":
 			break;
 		case "test":
 			await test.execute(argv);

--- a/lib/commands/add.ts
+++ b/lib/commands/add.ts
@@ -36,12 +36,11 @@ command = {
 		return true;
 	},
 	async execute(argv) {
-		//command.template;
-		const config =  ProjectConfig.getConfig();
-		if (config == null) {
+		if (!ProjectConfig.hasLocalConfig()) {
 			Util.error("Add command is supported only on existing project created with igniteui-cli", "red");
 			return;
 		}
+		const config =  ProjectConfig.getConfig();
 		if (config.project.isShowcase) {
 			Util.error("Showcases and quickstart projects don't support the add command", "red");
 			return;

--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -85,7 +85,7 @@ const command = {
 
 		config[argv.property] = argv.value;
 		ProjectConfig.setConfig(config, argv.global);
-		Util.log(`Property "${argv.property}" set`);
+		Util.log(`Property "${argv.property}" set.`);
 	},
 	addHandler(argv) {
 		let config;

--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -29,6 +29,20 @@ const command = {
 				}
 			},
 			handler: command.setHandler
+		}).command({
+			command: "add <property> <value>",
+			desc: "Add a value to an existing configuration array",
+			builder: {
+				property: {
+					describe: "Config property to add to",
+					type: "string"
+				},
+				value: {
+					describe: "New value to add",
+					type: "string"
+				}
+			},
+			handler: command.addHandler
 		}).option("global", {
 			alias: "g",
 			type: "boolean",
@@ -70,6 +84,36 @@ const command = {
 		config[argv.property] = argv.value;
 		ProjectConfig.setConfig(config, argv.global);
 		Util.log(`Property "${argv.property}" set`);
+	},
+	addHandler(argv) {
+		let config;
+
+		if (argv.global) {
+			config = ProjectConfig.globalConfig();
+		} else {
+			if (!ProjectConfig.hasLocalConfig()) {
+				Util.error("No configuration file found in this folder!", "red");
+				return;
+			}
+			config = ProjectConfig.localConfig();
+		}
+
+		// TODO: Schema/property validation?
+		if (!config[argv.property]) {
+			config[argv.property] = [];
+		} else if (!Array.isArray(config[argv.property])) {
+			Util.error(`Configuration property "${argv.property}" is not an array, use config set instead.`, "red");
+			return;
+		}
+
+		if (config[argv.property].indexOf(argv.value) !== -1) {
+			Util.log(`Value already exists in "${argv.property}".`);
+			return;
+		}
+
+		config[argv.property].push(argv.value);
+		ProjectConfig.setConfig(config, argv.global);
+		Util.log(`Property "${argv.property}" updated.`);
 	}
 };
 

--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -1,0 +1,76 @@
+import { Util } from "../Util";
+import { ProjectConfig } from "./../ProjectConfig";
+
+const command = {
+	command: "config",
+	desc: "Get or set configuration properties",
+	builder: yargs => {
+		yargs.command({
+			command: "get <property>",
+			desc: "Get configuration properties",
+			builder: {
+				property: {
+					describe: "Config property to get",
+					type: "string"
+				}
+			},
+			handler: command.getHandler
+		}).command({
+			command: "set <property> <value>",
+			desc: "Set configuration properties",
+			builder: {
+				property: {
+					describe: "Config property to set",
+					type: "string"
+				},
+				value: {
+					describe: "New value for the property",
+					type: "string"
+				}
+			},
+			handler: command.setHandler
+		}).option("global", {
+			alias: "g",
+			type: "boolean",
+			global: true,
+			describe: "Specify if the global configuration should be used"
+		})
+		// at least one command is required
+		.demand(1, "Please use either get or set command");
+	},
+	getHandler(argv) {
+		if (!argv.global && !ProjectConfig.hasLocalConfig()) {
+			Util.error("No configuration file found in this folder!", "red");
+			return;
+		}
+		const config = ProjectConfig.getConfig(argv.global);
+		if (config[argv.property] !== undefined) {
+			Util.log(config[argv.property]);
+		} else {
+			Util.error(`No value found for "${argv.property}" property`, "red");
+		}
+	},
+	setHandler(argv) {
+		let config;
+
+		if (argv.global) {
+			config = ProjectConfig.globalConfig();
+		} else {
+			if (!ProjectConfig.hasLocalConfig()) {
+				Util.error("No configuration file found in this folder!", "red");
+				return;
+			}
+			config = ProjectConfig.localConfig();
+		}
+
+		if (config[argv.property]) {
+			// TODO: Schema/property validation?
+		}
+
+		config[argv.property] = argv.value;
+		ProjectConfig.setConfig(config, argv.global);
+		Util.log(`Property "${argv.property}" set`);
+	}
+};
+
+export default command;

--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -2,6 +2,7 @@ import { Util } from "../Util";
 import { ProjectConfig } from "./../ProjectConfig";
 
 const command = {
+	// tslint:disable:object-literal-sort-keys
 	command: "config",
 	desc: "Get or set configuration properties",
 	builder: yargs => {
@@ -52,6 +53,7 @@ const command = {
 		// at least one command is required
 		.demand(1, "Please use either get or set command");
 	},
+	// tslint:enable:object-literal-sort-keys
 	getHandler(argv) {
 		if (!argv.global && !ProjectConfig.hasLocalConfig()) {
 			Util.error("No configuration file found in this folder!", "red");

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -40,7 +40,7 @@ command = {
 	},
 	template: null,
 	async execute(argv) {
-		if (ProjectConfig.getConfig() !== null) {
+		if (ProjectConfig.hasLocalConfig()) {
 			return Util.error("There is already an existing project.", "red");
 		}
 		if (!argv.name && !argv.type && !argv.theme) {

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -1,3 +1,4 @@
 {
-	"igPackageRegistry": "https://packages.infragistics.com/npm/js-licensed/"
+	"igPackageRegistry": "https://packages.infragistics.com/npm/js-licensed/",
+	"customTemplates": []
 }

--- a/lib/config/defaults.json
+++ b/lib/config/defaults.json
@@ -1,0 +1,3 @@
+{
+	"igPackageRegistry": "https://packages.infragistics.com/npm/js-licensed/"
+}

--- a/lib/types/Config.d.ts
+++ b/lib/types/Config.d.ts
@@ -27,11 +27,16 @@ declare interface Config {
 		igniteuiSource: string;
 
 		[key: string]: any;
-	};
+	}
 	build: {
 		/** This object contains information related to the build configuration
 		 *  and server configuration of the project */
 		//"projectBuild": "tsc",
 		//"serverType": "webpack"
-	};
+	}
+
+	/** An array of paths to red custom templates from */
+	customTemplates: string[];
+	/** Infragistics package registry Url */
+	igPackageRegistry: string;
 }

--- a/lib/types/Config.d.ts
+++ b/lib/types/Config.d.ts
@@ -35,7 +35,7 @@ declare interface Config {
 		//"serverType": "webpack"
 	}
 
-	/** An array of paths to red custom templates from */
+	/** An array of paths to read custom templates from */
 	customTemplates: string[];
 	/** Infragistics package registry Url */
 	igPackageRegistry: string;

--- a/spec/acceptance/help-spec.ts
+++ b/spec/acceptance/help-spec.ts
@@ -10,6 +10,7 @@ describe("Help command", () => {
 		start                  start the project
 		new [name]             Creating a new project
 		build                  build the project
+		config                 Get or set configuration properties
 		test                   test the project
 		add [template] [name]  Add component by it ID and providing a name.
 	  Options:
@@ -35,6 +36,27 @@ describe("Help command", () => {
 				  [string] [choices: "angular", "jquery", "react"] [default: "jquery"]
 		--type, -t       Project type (depends on framework)                  [string]
 		--theme, --th    Project theme (depends on project type)              [string]`;
+
+		const replacedNewHelpText: string = originalNewHelpText.replace(/\s/g, "");
+		const actualNewText: string = (child.stdout.toString("utf-8")).replace(/\s/g, "");
+
+		expect(actualNewText).toContain(replacedNewHelpText);
+		done();
+	});
+
+	it("should show help config sub-commands", async done => {
+		const child = spawnSync("node", ["bin/execute.js", "config", "--help" ], {
+			encoding: "utf-8"
+		});
+		const originalNewHelpText: string = `Commands:
+		get <property>          Get configuration properties
+		set <property> <value>  Set configuration properties
+		add <property> <value>  Add a value to an existing configuration array
+
+		Options:
+		--version, -v  Show current Ignite UI CLI version                    [boolean]
+		--help, -h     Show help                                             [boolean]
+		--global, -g   Specify if the global configuration should be used    [boolean]`;
 
 		const replacedNewHelpText: string = originalNewHelpText.replace(/\s/g, "");
 		const actualNewText: string = (child.stdout.toString("utf-8")).replace(/\s/g, "");

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -8,7 +8,7 @@ import * as glob from "glob";
 export function deleteAll(folderPath: string) {
 	const files: string[] = glob.sync(folderPath + "/**/*", { nodir: true, dot: true });
 	files.forEach(x => fs.unlinkSync(x));
-	const folders: string[] = glob.sync(folderPath + "/**/*");
+	const folders: string[] = glob.sync(folderPath + "/**/*", { dot: true });
 	folders.reverse().forEach(x => fs.rmdirSync(x));
 }
 

--- a/spec/unit/add-spec.ts
+++ b/spec/unit/add-spec.ts
@@ -9,6 +9,7 @@ import { resetSpy } from "../helpers/utils";
 describe("Unit - Add command", () => {
 
 	it("Should start prompt session with missing arg", async done => {
+		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
 			theme: "infragistics"}});

--- a/spec/unit/config-spec.ts
+++ b/spec/unit/config-spec.ts
@@ -74,7 +74,7 @@ describe("Unit - Config command", () => {
 			expect(ProjectConfig.localConfig).toHaveBeenCalledTimes(0);
 			expect(ProjectConfig.globalConfig).toHaveBeenCalled();
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ test: true }, true /*global*/);
-			expect(Util.log).toHaveBeenCalledWith(`Property "test" set`);
+			expect(Util.log).toHaveBeenCalledWith(`Property "test" set.`);
 			done();
 		});
 
@@ -89,7 +89,7 @@ describe("Unit - Config command", () => {
 			expect(ProjectConfig.globalConfig).toHaveBeenCalledTimes(0);
 			expect(ProjectConfig.localConfig).toHaveBeenCalled();
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ notTest: "ig", test: true }, undefined);
-			expect(Util.log).toHaveBeenCalledWith(`Property "test" set`);
+			expect(Util.log).toHaveBeenCalledWith(`Property "test" set.`);
 			done();
 		});
 	});

--- a/spec/unit/config-spec.ts
+++ b/spec/unit/config-spec.ts
@@ -1,0 +1,93 @@
+import { default as configCmd } from "../../lib/commands/config";
+import { ProjectConfig } from "../../lib/ProjectConfig";
+import { Util } from "../../lib/Util";
+
+describe("Unit - Config command", () => {
+
+	describe("Get", () => {
+		it("Should show error w/o existing project and global flag", async done => {
+			spyOn(Util, "error");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+
+			await configCmd.getHandler({ property: "test" });
+			expect(Util.error).toHaveBeenCalledWith("No configuration file found in this folder!", "red");
+			done();
+		});
+
+		it("Should show error for missing prop", async done => {
+			spyOn(Util, "error");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({ notTest: "ig" });
+
+			await configCmd.getHandler({ property: "test" });
+			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(undefined);
+			expect(Util.error).toHaveBeenCalledWith(`No value found for "test" property`, "red");
+			done();
+		});
+
+		it("Should show error for missing prop and global flag", async done => {
+			spyOn(Util, "error");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({ notTest: "ig" });
+
+			await configCmd.getHandler({ property: "test", global: true });
+			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(true);
+			expect(Util.error).toHaveBeenCalledWith(`No value found for "test" property`, "red");
+			done();
+		});
+
+		it("Should return value for property", async done => {
+			spyOn(Util, "log");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({ test: "igValue" });
+
+			await configCmd.getHandler({ property: "test" });
+			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(undefined);
+			expect(Util.log).toHaveBeenCalledWith("igValue");
+			done();
+		});
+	});
+
+	describe("Set", () => {
+		it("Should show error w/o existing project and global flag", async done => {
+			spyOn(Util, "error");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+
+			await configCmd.setHandler({ property: "test", value: true });
+			expect(Util.error).toHaveBeenCalledWith("No configuration file found in this folder!", "red");
+			done();
+		});
+
+		it("Should set global prop", async done => {
+			spyOn(Util, "log");
+			spyOn(ProjectConfig, "hasLocalConfig");
+			spyOn(ProjectConfig, "globalConfig").and.returnValue({ test: "ig" });
+			spyOn(ProjectConfig, "localConfig");
+			spyOn(ProjectConfig, "setConfig");
+
+			await configCmd.setHandler({ property: "test", value: true, global: true });
+
+			expect(ProjectConfig.hasLocalConfig).toHaveBeenCalledTimes(0);
+			expect(ProjectConfig.localConfig).toHaveBeenCalledTimes(0);
+			expect(ProjectConfig.globalConfig).toHaveBeenCalled();
+			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ test: true }, true /*global*/);
+			expect(Util.log).toHaveBeenCalledWith(`Property "test" set`);
+			done();
+		});
+
+		it("Should set local prop", async done => {
+			spyOn(Util, "log");
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "localConfig").and.returnValue({ notTest: "ig" });
+			spyOn(ProjectConfig, "globalConfig");
+			spyOn(ProjectConfig, "setConfig");
+
+			await configCmd.setHandler({ property: "test", value: true });
+			expect(ProjectConfig.globalConfig).toHaveBeenCalledTimes(0);
+			expect(ProjectConfig.localConfig).toHaveBeenCalled();
+			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ notTest: "ig", test: true }, undefined);
+			expect(Util.log).toHaveBeenCalledWith(`Property "test" set`);
+			done();
+		});
+	});
+});

--- a/spec/unit/new-spec.ts
+++ b/spec/unit/new-spec.ts
@@ -12,7 +12,7 @@ describe("Unit - New command", () => {
 
 	it("New command in existing project", async done => {
 		spyOn(Util, "error");
-		spyOn(ProjectConfig, "getConfig").and.returnValue({});
+		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 
 		await newCmd.execute({});
 		expect(Util.error).toHaveBeenCalledWith("There is already an existing project.", "red");


### PR DESCRIPTION
Initial changes for #67

The would-be page in the wiki:
---
# ig config

## Overview
The `ig config` performs read and write operation on the Ignite UI CLI configuration settings. The CLI stores configuration in an `ignite-ui-cli.json` file matching the [`Config`](https://github.com/IgniteUI/igniteui-cli/blob/master/lib/types/Config.d.ts) interface. Project structures created with the CLI include such file as local configuration and a per-user file can provide global defaults. The global file is stored under the current user home directory - usually `/home/<user>` for Unix and `C:\Users\<user>` for Windows. 


Config is split into [sub-commands](#sub-commands) for each operation:
```bash
ig config <get|set|add> <property> [value]
```

The following properties are available globally:

Property |    Type    | Description
---------|------------|------------
igPackageRegistry | `string` | The URL of the Infragistics Npm package registry
customTemplates | `string[]` | A list of paths to load additional templates from



## Sub-commands

### Get 
```bash
ig config get <property>
```
<details>
  <summary>global</summary>
  <p>
    <code>--global</code> (alias: <code>-g</code>) <em>Specify if the global configuration value should be returned</em>
  </p>
</details>
Prints out the value for a given configuration property in the console. This value is effective - depending on global defaults and the current local project config (if not present in).

### Set 
```bash
ig config set <property> <value>
```
<details>
  <summary>global</summary>
  <p>
    <code>--global</code> (alias: <code>-g</code>) <em>Specify if the global configuration value should be updated</em>
  </p>
</details>
Sets a the value for a given configuration property.

### Add 
```bash
ig config add <property> <value>
```
<details>
  <summary>global</summary>
  <p>
    <code>--global</code> (alias: <code>-g</code>) <em>Specify if the global configuration value should be updated</em>
  </p>
</details>
Adds a value to a configuration list.