### PR TITLE
fix: set responsive directives and styles for home and existing component templates.

### DIFF
--- a/templates/angular/igx-ts/carousel/default/files/src/app/__path__/__name__.component.html
+++ b/templates/angular/igx-ts/carousel/default/files/src/app/__path__/__name__.component.html
@@ -1,7 +1,7 @@
-<div>
+<div igxLayout igxLayoutDir="columns" igxLayoutItemAlign="center">
 	<p>igx-carousel component. You can read more about configuring the igx-carousel component
 		<a href="https://github.com/IgniteUI/igniteui-angular/blob/master/src/carousel/README.md" target="_blank">here</a>.</p>
-	<igx-carousel [interval]="interval" [pause]="pause" [loop]="loop">
+	<igx-carousel [interval]="interval" [pause]="pause" [loop]="loop" igxLayout igxLayoutJustify="center">
 		<igx-slide *ngFor="let slide of slides;" [active]="slide.active">
 			<img [src]="slide.image">
 		</igx-slide>

--- a/templates/angular/igx-ts/custom-templates/awesome-grid/index.ts
+++ b/templates/angular/igx-ts/custom-templates/awesome-grid/index.ts
@@ -16,7 +16,8 @@ class IgxGridAwesomeTemplate extends IgniteUIForAngularTemplate {
 			"IgxIconModule",
 			"IgxAvatarModule",
 			"IgxBadgeModule",
-			"IgxSwitchModule"
+			"IgxSwitchModule",
+			"IgxInputModule"
 		];
 	}
 }

--- a/templates/angular/igx-ts/date-picker/default/files/src/app/__path__/__name__.component.html
+++ b/templates/angular/igx-ts/date-picker/default/files/src/app/__path__/__name__.component.html
@@ -1,4 +1,4 @@
-<div>
+<div igxLayout igxLayoutDir="columns" igxLayoutItemAlign="center">
 	<p>igx-date-picker component. You can read more about configuring the igx-date-picker component
 		<a href="https://github.com/IgniteUI/igniteui-angular/blob/master/src/date-picker/README.md" target="_blank">here</a>.</p>
 		<igx-datePicker [cancelButtonLabel]="'Close'"[todayButtonLabel]="'Today'" [value]="today"></igx-datePicker>

--- a/templates/angular/igx-ts/projects/empty/files/package.json
+++ b/templates/angular/igx-ts/projects/empty/files/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve -o",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/templates/angular/igx-ts/projects/empty/files/src/app/app.component.css
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/app.component.css
@@ -1,12 +1,7 @@
 .main {
 	width: 100%;
 }
- 
-h3 {
-  padding-left: 16px;
-}
 
 .content {
   flex: 1 1 100%;
-  padding: 20px;
 }

--- a/templates/angular/igx-ts/projects/empty/files/src/app/app.component.html
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/app.component.html
@@ -7,9 +7,8 @@
 	</igx-nav-drawer>
 	<div igxFlex>
 		<igx-navbar title="IgniteUI for Angular!" actionButtonIcon="menu" (onAction)="nav.toggle()" igxFlex></igx-navbar>
-		<div class="content">
+		<div class="content" igxLayout igxLayoutJustify="center">
 			<router-outlet></router-outlet>
 		 </div>
 	  </div>
   </div>
-  

--- a/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.css
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.css
@@ -3,15 +3,20 @@ a {
 }
 
 .links{
-  display: inline-block;
   text-align: center;
-  flex: 1 1 33%;
+  padding: 0 10px;
 }
 
-ul#linksContainer {
+#linksContainer {
+  flex-flow: row wrap;
   display: flex;
+  justify-content: center;
 }
 
-:host {
-  width: 55%;
+:host{
+  text-align:center;
+}
+
+img {
+  max-width:100%;
 }

--- a/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.css
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.css
@@ -11,3 +11,7 @@ a {
 ul#linksContainer {
   display: flex;
 }
+
+:host {
+  width: 55%;
+}

--- a/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.html
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/home/home.component.html
@@ -1,19 +1,11 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<div style="text-align:center">
-  <h1>
-    Welcome to {{title}}!
-  </h1>
-  <img src="assets/responsive.gif" alt="Ignite UI CLI">
-</div>
+<h1>
+  Welcome to {{title}}!
+</h1>
+<img src="assets/responsive.gif" alt="Ignite UI CLI">
 
-<ul id="linksContainer">
-  <li class="links">
-    <h3><a target="_blank" rel="noopener" href="https://github.com/IgniteUI/ignite-ui-cli">Ignite UI CLI </a></h3>
-  </li>
-  <li class="links">
-      <h3><a target="_blank" rel="noopener" href="https://www.infragistics.com/products/ignite-ui-angular">Component Demos</a></h3>
-  </li>
-  <li class="links">
-    <h3><a target="_blank" rel="noopener" href="https://github.com/IgniteUI/igniteui-angular-ui-kits">Sketch UI Kit</a></h3>
-  </li>
-</ul>
+<div id="linksContainer">
+    <h3 class="links"><a target="_blank" rel="noopener" href="https://github.com/IgniteUI/ignite-ui-cli">Ignite UI CLI </a></h3>
+    <h3 class="links"><a target="_blank" rel="noopener" href="https://www.infragistics.com/products/ignite-ui-angular">Component Demos</a></h3>
+    <h3 class="links"><a target="_blank" rel="noopener" href="https://github.com/IgniteUI/igniteui-angular-ui-kits">Sketch UI Kit</a></h3>
+</div>


### PR DESCRIPTION
Set responsive directives and styles for home and existing component templates.
Using igxLayout. Update the _ng serve_ to open a new browser instance when serving the app via _ng serve -o_