### PR TITLE
fix: change the regex to allow single letter name

### DIFF
--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -258,7 +258,7 @@ class Util {
 	 * @param name Text to check
 	 */
 	public static isAlphanumericExt(name: string) {
-		return /^[\sa-zA-Z][\w\s\-]+$/.test(name);
+		return /^[\sa-zA-Z][\w\s\-]*$/.test(name);
 	}
 
 	/**

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -25,14 +25,15 @@ export async function run(args = null) {
 
 	const yargsModule = args ? yargs(args) : yargs;
 
-	const argv = yargsModule.command(quickstart)
-	.command(start)
+	const argv = yargsModule
+	.command(quickstart)
 	.command(newCommand)
-	.command(generate)
+	.command(add)
 	.command(build)
+	.command(start)
+	.command(generate)
 	.command(config)
 	.command(test)
-	.command(add)
 	.options({
 		version: {
 			alias: "v",

--- a/lib/commands/add.ts
+++ b/lib/commands/add.ts
@@ -13,7 +13,7 @@ let command: {
 // tslint:disable:object-literal-sort-keys
 command = {
 	command: "add [template] [name]",
-	desc: "Add component by it ID and providing a name.",
+	desc: "adds template by its ID",
 	templateManager: null,
 	builder: {
 		template: {
@@ -79,7 +79,7 @@ command = {
 		// letter+alphanumeric check
 		if (!Util.isAlphanumericExt(name)) {
 			Util.error(`Name '${name}' is not valid. `
-				+ "Template names should start with a letter and can also contain numbers, dashes and spaces.",
+				+ "Names should start with a letter and can also contain numbers, dashes and spaces.",
 				"red");
 			return false;
 		}

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -7,7 +7,7 @@ import { ProjectConfig } from "./../ProjectConfig";
 // tslint:disable:object-literal-sort-keys
 const command = {
 	command: "build",
-	desc: "build the project",
+	desc: "builds the project",
 	builder: {},
 	async execute(argv?) {
 		Util.log("Build started.");

--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -4,11 +4,11 @@ import { ProjectConfig } from "./../ProjectConfig";
 const command = {
 	// tslint:disable:object-literal-sort-keys
 	command: "config",
-	desc: "Get or set configuration properties",
+	desc: "gets, sets or adds a configuration property",
 	builder: yargs => {
 		yargs.command({
 			command: "get <property>",
-			desc: "Get configuration properties",
+			desc: "Gets a configuration property",
 			builder: {
 				property: {
 					describe: "Config property to get",
@@ -18,7 +18,7 @@ const command = {
 			handler: command.getHandler
 		}).command({
 			command: "set <property> <value>",
-			desc: "Set configuration properties",
+			desc: "Sets a configuration property",
 			builder: {
 				property: {
 					describe: "Config property to set",
@@ -32,7 +32,7 @@ const command = {
 			handler: command.setHandler
 		}).command({
 			command: "add <property> <value>",
-			desc: "Add a value to an existing configuration array",
+			desc: "Adds a value to an existing configuration array",
 			builder: {
 				property: {
 					describe: "Config property to add to",

--- a/lib/commands/generate.ts
+++ b/lib/commands/generate.ts
@@ -7,7 +7,7 @@ import { default as config } from "./config";
 const command = {
 	aliases: ["g"],
 	command: "generate",
-	desc: "Generates new project",
+	desc: "generates custom template",
 	templateManager: null,
 	// tslint:disable-next-line:object-literal-sort-keys
 	builder: yargs => {
@@ -15,7 +15,7 @@ const command = {
 			.command({
 				aliases: ["t"],
 				command: "template [name]",
-				desc: "Generates custom template",
+				desc: "generates custom template",
 				// tslint:disable-next-line:object-literal-sort-keys
 				builder: {
 					"framework": {

--- a/lib/commands/new.ts
+++ b/lib/commands/new.ts
@@ -13,7 +13,7 @@ let command: {
 // tslint:disable:object-literal-sort-keys
 command = {
 	command: "new [name]",
-	desc: "Creating a new project",
+	desc: "creates a project",
 	builder: {
 		"name": {
 			alias: "n",
@@ -98,6 +98,12 @@ command = {
 		Util.log(Util.greenCheck() + " Project Created");
 
 		this.git(argv["skip-git"], argv.name);
+
+		Util.log("");
+		Util.log("Next Steps:");
+		Util.log(`  cd ${argv.name}`);
+		Util.log("  ig start starts the project");
+		Util.log("  ig add [template] [name] adds template by its ID");
 	},
 	git(skipGit, projectName) {
 		if (!skipGit) {

--- a/lib/commands/quickstart.ts
+++ b/lib/commands/quickstart.ts
@@ -9,7 +9,7 @@ import shell = require("shelljs");
 // tslint:disable:object-literal-sort-keys
 const command = {
 	command: "quickstart",
-	desc: "A quick start for your project",
+	desc: "creates rich feature grid",
 	builder: {
 		framework: {
 			alias: "f",

--- a/lib/commands/start.ts
+++ b/lib/commands/start.ts
@@ -8,7 +8,7 @@ import { default as build } from "./build";
 // tslint:disable:object-literal-sort-keys
 const command = {
 	command: "start",
-	desc: "start the project",
+	desc: "starts the project",
 	builder: {},
 	async execute(argv) {
 		//build
@@ -24,7 +24,6 @@ const command = {
 				liteServ.server();
 				break;
 			case "react":
-				Util.log(process.cwd());
 				exec("npm start");
 				break;
 			case "angular":

--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -3,7 +3,7 @@ import { Util } from "../Util";
 const command = {
 	// tslint:disable:object-literal-sort-keys
 	command: "test",
-	desc: "test the project",
+	desc: "tests the project",
 	builder: {},
 	async execute(argv) {
 		Util.log("test!");

--- a/spec/acceptance/help-spec.ts
+++ b/spec/acceptance/help-spec.ts
@@ -6,14 +6,14 @@ describe("Help command", () => {
 			encoding: "utf-8"
 		});
 		const originalHelpText: string = `Commands:
-		quickstart             A quick start for your project
-		start                  start the project
-		new [name]             Creating a new project
-		generate               Generates new project                      [aliases: g]
-		build                  build the project
-		config                 Get or set configuration properties
-		test                   test the project
-		add [template] [name]  Add component by it ID and providing a name.
+		quickstart             creates rich feature grid
+		new [name]             creates a project
+		add [template] [name]  adds template by its ID
+		build                  builds the project
+		start                  starts the project
+		generate               generates custom template                  [aliases: g]
+		config                 gets, sets or adds a configuration property
+		test                   tests the project
 	  Options:
 		--version, -v  Show current Ignite UI CLI version                    [boolean]
 		--help, -h     Show help                                             [boolean]`;
@@ -50,9 +50,9 @@ describe("Help command", () => {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `Commands:
-		get <property>          Get configuration properties
-		set <property> <value>  Set configuration properties
-		add <property> <value>  Add a value to an existing configuration array
+		get <property>          Gets a configuration property
+		set <property> <value>  Sets a configuration property
+		add <property> <value>  Adds a value to an existing configuration array
 
 		Options:
 		--version, -v  Show current Ignite UI CLI version                    [boolean]
@@ -70,7 +70,7 @@ describe("Help command", () => {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `Commands:
-		template	[name]	Generates custom template		[aliases: t]
+		template	[name]	generates custom template		[aliases: t]
 
 		Options:
 		--version,	-v	Show current Ignite UI CLI version	[boolean]

--- a/spec/acceptance/new-spec.ts
+++ b/spec/acceptance/new-spec.ts
@@ -74,4 +74,15 @@ describe("New command", () => {
 		expect(fs.existsSync("./" + projectName + "/.git")).not.toBeTruthy();
 		done();
 	});
+
+	it("Creates project with single word name", async done => {
+		const projectName = "a";
+		await cli.run(["new", projectName, "--framework=jquery"]);
+
+		//TODO: read entire structure from ./templates and verify everything is copied over
+		expect(fs.existsSync("./a")).toBeTruthy();
+
+		this.testFolder = "./a";
+		done();
+	});
 });

--- a/spec/unit/add-spec.ts
+++ b/spec/unit/add-spec.ts
@@ -49,14 +49,15 @@ describe("Unit - Add command", () => {
 			resetSpy(Util.error);
 			await addCmd.addTemplate(item.name, mockTemplate);
 			expect(Util.error).toHaveBeenCalledWith(`Name '${item.inError}' is not valid. `
-			+ "Template names should start with a letter and can also contain numbers, dashes and spaces.", "red");
+			+ "Names should start with a letter and can also contain numbers, dashes and spaces.", "red");
 		}
 
 		const validCombos = [
 			{ name: "   valid  name  \t   ", valid: "valid  name" },
 			{ name: "th1s is valid", valid: "th1s is valid" },
 			{ name: "b1ts-and bobs ", valid: "b1ts-and bobs" },
-			{ name: "a      name", valid: "a      name" }
+			{ name: "a      name", valid: "a      name" },
+			{ name: "a", valid: "a" } // single letter name test
 		];
 
 		for (const item of validCombos) {


### PR DESCRIPTION
Closes #173

cli.ts - reordering the commands to show correctly in the help
for all commands change the description as discussed with UX
fix all failing tests
