### PR TITLE
fix: in installPackages method enable skipAnalytic

### DIFF
--- a/lib/packages/PackageManager.ts
+++ b/lib/packages/PackageManager.ts
@@ -66,6 +66,9 @@ export class PackageManager {
 			let command: string;
 			let managerCommand: string;
 
+			const oldSkipAnalytic = config.skipAnalytic;
+			config.skipAnalytic = true;
+
 			managerCommand = this.getManager();
 			switch (managerCommand) {
 				case "npm":
@@ -85,9 +88,9 @@ export class PackageManager {
 				Util.log(`Packages installed successfully`);
 			}
 			config.packagesInstalled = true;
+			config.skipAnalytic = oldSkipAnalytic;
 			ProjectConfig.setConfig(config);
 		}
-
 	}
 
 	public static removePackage(packageName: string, verbose: boolean = false): boolean {

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -186,7 +186,8 @@ describe("Unit - Package Manager", () => {
 	});
 	it("Should run installPackages properly with error code", async done => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({
-			packagesInstalled: false
+			packagesInstalled: false,
+			skipAnalytic: false
 		});
 		spyOn(Util, "log");
 		spyOn(shell, "exec").and.returnValue({
@@ -201,12 +202,13 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Error installing npm packages.`);
 		expect(Util.log).toHaveBeenCalledWith(`Example`);
 		expect(shell.exec).toHaveBeenCalledWith(`npm install --quiet`, {silent: true});
-		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({packagesInstalled: true});
+		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({packagesInstalled: true, skipAnalytic: false});
 		done();
 	});
 	it("Should run installPackages properly without error code", async done => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({
-			packagesInstalled: false
+			packagesInstalled: false,
+			skipAnalytic: true
 		});
 		spyOn(Util, "log");
 		spyOn(shell, "exec").and.returnValue({
@@ -219,7 +221,7 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Installing npm packages`);
 		expect(Util.log).toHaveBeenCalledWith(`Packages installed successfully`);
 		expect(shell.exec).toHaveBeenCalledWith(`npm install --quiet`, {silent: true});
-		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({packagesInstalled: true});
+		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({packagesInstalled: true, skipAnalytic: true});
 		done();
 	});
 	it("Should run removePackage properly with error code", async done => {


### PR DESCRIPTION
in installPackages method enable skipAnalytic in order to not send data before npm install, and disable it after

Closes #241


