### PR TITLE
chore: freeze igniteui-angular version to 6.0.0

### DIFF
--- a/templates/angular/igx-ts/projects/empty/files/package.json
+++ b/templates/angular/igx-ts/projects/empty/files/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "^6.0.0",
     "core-js": "^2.5.4",
     "hammerjs": "^2.0.8",
-    "igniteui-angular": "^6.0.0",
+    "igniteui-angular": "6.0.0",
     "rxjs": "^6.0.0",
     "zone.js": "^0.8.26",
     "web-animations-js": "^2.3.1"
@@ -38,7 +38,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
     "codelyzer": "~4.2.1",
-    "igniteui-cli": "^$(cliVersion)",
+    "igniteui-cli": "~$(cliVersion)",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~1.7.1",


### PR DESCRIPTION
chore: freeze igniteui-angular version to 6.0.0, update the cli internal reference to use minor version
