### PR TITLE
Templates - Angular - Add module dependencies to component templates

### DIFF
--- a/templates/angular/igx-ts/carousel/default/index.ts
+++ b/templates/angular/igx-ts/carousel/default/index.ts
@@ -11,7 +11,8 @@ class IgxCarouselTemplate extends IgniteUIForAngularTemplate {
 		this.name = "Carousel";
 		this.description = "Basic IgxCarousel";
 		this.dependencies = [
-			{ import: "IgxCarouselModule", from: "igniteui-angular" }
+			{ import: "IgxCarouselModule", from: "igniteui-angular" },
+			{ import: "CommonModule", from: "@angular/common"}
 		];
 	}
 }

--- a/templates/angular/igx-ts/list/default/index.ts
+++ b/templates/angular/igx-ts/list/default/index.ts
@@ -12,7 +12,14 @@ class IgxListTemplate extends IgniteUIForAngularTemplate {
 		this.description = "Basic IgxList";
 		this.dependencies = [{
 			from: "igniteui-angular",
-			import: ["IgxListModule", "IgxAvatarModule", "IgxIconModule", "IgxInputGroupModule", "IgxFilterModule"]
+			import: ["IgxListModule", "IgxAvatarModule", "IgxIconModule",
+			"IgxInputGroupModule", "IgxFilterModule"]
+		}, {
+			from: "@angular/common",
+			import: ["CommonModule"]
+		}, {
+			from: "@angular/forms",
+			import: ["FormsModule"]
 		}];
 	}
 }

--- a/templates/angular/igx-ts/tabbar/default/index.ts
+++ b/templates/angular/igx-ts/tabbar/default/index.ts
@@ -13,6 +13,9 @@ class IgxBottomNavTemplate extends IgniteUIForAngularTemplate {
 		this.dependencies = [{
 			from: "igniteui-angular",
 			import: ["IgxBottomNavModule", "IgxAvatarModule", "IgxIconModule", "IgxRippleModule"]
+		}, {
+			from: "@angular/common",
+			import: "CommonModule"
 		}];
 	}
 }


### PR DESCRIPTION
Closes #273.  

List, Carousel and Tabbar (Bottom-Nav) component templates were missing some module dependencies.
This caused the app to fail to render if these were added to a custom module (non app.module.ts).

Dependencies are now added.

