### PR TITLE
Command - Add - Add to custom module accepts module through alias ('m')

### DIFF
--- a/lib/commands/add.ts
+++ b/lib/commands/add.ts
@@ -94,8 +94,8 @@ command = {
 				cd11: !!config.skipGit,
 				cd14: config.project.theme
 			});
-
-			await command.addTemplate(argv.name, selectedTemplate, argv.module);
+			const selectedModule = argv.module || argv.m;
+			await command.addTemplate(argv.name, selectedTemplate, selectedModule);
 			await PackageManager.flushQueue(true);
 			PackageManager.ensureIgniteUISource(config.packagesInstalled, command.templateManager);
 		}


### PR DESCRIPTION
Custom module for add command can be passed under -m, e.g. `-m=module-path/module-name.module.ts`

