### PR TITLE
Do not push to GA on non-global install and uninstal

### DIFF
--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -1,11 +1,13 @@
 import { GoogleAnalytics } from "../lib/GoogleAnalytics";
 
 function install() {
-	GoogleAnalytics.post({
-		t: "screenview",
-		// tslint:disable-next-line:object-literal-sort-keys
-		cd: `install global: ${!!process.env.npm_config_global}`
-	});
+	if (!!process.env.npm_config_global) {
+		GoogleAnalytics.post({
+			t: "screenview",
+			// tslint:disable-next-line:object-literal-sort-keys
+			cd: `install`
+		});
+	}
 }
 
 install();

--- a/scripts/uninstall.ts
+++ b/scripts/uninstall.ts
@@ -1,11 +1,13 @@
 import { GoogleAnalytics } from "../lib/GoogleAnalytics";
 
 function uninstall() {
-	GoogleAnalytics.post({
-		t: "screenview",
-		// tslint:disable-next-line:object-literal-sort-keys
-		cd: `uninstall global: ${!!process.env.npm_config_global}`
-	});
+	if (!!process.env.npm_config_global) {
+		GoogleAnalytics.post({
+			t: "screenview",
+			// tslint:disable-next-line:object-literal-sort-keys
+			cd: `uninstall`
+		});
+		}
 }
 
 uninstall();


### PR DESCRIPTION
Up to now we were sending GA information on each install and uninstall. However, as each call to
`npm install`
in project containing igniteui-cli forces starting of install and uninstall scripts in non-global mode, we decided to start these scripts only when installation is global.