### PR TITLE
chore(igx): limit igniteui-angular to 6.1.x for existing projects

### DIFF
--- a/templates/angular/igx-ts/projects/empty/files/package.json
+++ b/templates/angular/igx-ts/projects/empty/files/package.json
@@ -24,7 +24,7 @@
     "core-js": "^2.5.4",
     "jszip": "^3.1.5",
     "hammerjs": "^2.0.8",
-    "igniteui-angular": "^6.1.1",
+    "igniteui-angular": "~6.1.1",
     "rxjs": "^6.0.0",
     "zone.js": "^0.8.26",
     "web-animations-js": "^2.3.1"


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

