### PR TITLE
Misc fixes

### DIFF
--- a/lib/commands/quickstart.ts
+++ b/lib/commands/quickstart.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs-extra";
-import * as liteServer from "lite-server";
 import * as path from "path";
 import { GoogleAnalytics } from "../GoogleAnalytics";
 import { Util } from "../Util";
@@ -69,6 +67,9 @@ const command = {
 			Util.log("react-quickstart loaded");
 			shell.exec("npm install");
 			shell.exec("npm run webpack");
+			// lite-server installed per project
+			// tslint:disable-next-line:no-implicit-dependencies
+			const liteServer = require("lite-server");
 			liteServer.server();
 		}
 
@@ -80,6 +81,10 @@ const command = {
 
 		if (argv.framework === "jquery") {
 			Util.log("jquery-quickstart loaded");
+			shell.exec("npm install");
+			// lite-server installed per project
+			// tslint:disable-next-line:no-implicit-dependencies
+			const liteServer = require("lite-server");
 			liteServer.server();
 		}
 	}

--- a/lib/commands/start.ts
+++ b/lib/commands/start.ts
@@ -1,4 +1,3 @@
-import * as  bs from "browser-sync";
 import * as path from "path";
 import { exec } from "shelljs";
 import { GoogleAnalytics } from "../GoogleAnalytics";
@@ -63,6 +62,9 @@ command = {
 
 		switch (framework.toLowerCase()) {
 			case "jquery":
+			// browser-sync installed per project
+			// tslint:disable-next-line:no-implicit-dependencies
+			const bs = require("browser-sync");
 			const browserSync = bs.create("igniteui-cli");
 			const filePath = path.join(process.cwd(), "bs-config.js");
 			const bsConfig = require(filePath);

--- a/lib/packages/PackageManager.ts
+++ b/lib/packages/PackageManager.ts
@@ -23,7 +23,7 @@ export class PackageManager {
 		templateManager: TemplateManager,
 		verbose: boolean = false
 	) {
-		const config = ProjectConfig.getConfig();
+		const config = ProjectConfig.localConfig();
 		const fullComponents = config.project.components.filter(x => {
 			return componentsConfig.full.indexOf(x) !== -1 || componentsConfig.dv.indexOf(x) !== -1;
 		});
@@ -63,13 +63,10 @@ export class PackageManager {
 	}
 
 	public static async installPackages(verbose: boolean = false) {
-		const config = ProjectConfig.getConfig();
+		const config = ProjectConfig.localConfig();
 		if (!config.packagesInstalled) {
 			let command: string;
 			let managerCommand: string;
-
-			const oldSkipAnalytic = config.disableAnalytics;
-			config.disableAnalytics = true;
 
 			managerCommand = this.getManager();
 			switch (managerCommand) {
@@ -97,7 +94,6 @@ export class PackageManager {
 				}
 			}
 			config.packagesInstalled = true;
-			config.disableAnalytics = oldSkipAnalytic;
 			ProjectConfig.setConfig(config);
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
     "@types/fs-extra": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-3.0.3.tgz",
-      "integrity": "sha1-HWbrZw6/ZX5XwP2gFN80DBnYqgw=",
+      "integrity": "sha512-o2qkg/J2LWK+sr007+KFBBOrxzxpr9kiP0gMFC75gQJXhUn/E3pQA0kSVdxrQ3lf+rOwsRnuH0wnR5MNTotEKg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -75,7 +75,7 @@
     "@types/inquirer": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.35.tgz",
-      "integrity": "sha1-4FRlfPLRCWOCOVfU0G7CRPBcZb4=",
+      "integrity": "sha512-/6WyyGROIw6qCmS8KmQtyt9Tj1OX7xIrGloAwMMOaNb3W/+QrrlL4Be4TDvLO4dlvw8gFrHfeXiWxS/k82jgEQ==",
       "dev": true,
       "requires": {
         "@types/rx": "*",
@@ -253,6 +253,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
@@ -261,7 +262,8 @@
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -271,12 +273,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -306,7 +310,8 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
@@ -323,7 +328,8 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -333,23 +339,27 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
     },
     "async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
+      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "atob": {
       "version": "2.1.0",
@@ -361,6 +371,7 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.2.5",
         "is-buffer": "^1.1.5"
@@ -395,7 +406,8 @@
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -460,22 +472,26 @@
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
     },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
     },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
       "requires": {
         "callsite": "1.0.0"
       }
@@ -483,12 +499,14 @@
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -529,31 +547,35 @@
       }
     },
     "browser-sync": {
-      "version": "2.24.5",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.5.tgz",
-      "integrity": "sha512-r6ZRYncfYRGerw4Rh5S8Q9x9WKDdrwH572hd3ofsYgn0Px6a6EqXiLBVTCss2+2a45G9ZgjRHSeo9YY56UpgKw==",
+      "version": "2.26.3",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.3.tgz",
+      "integrity": "sha512-VLzpjCA4uXqfzkwqWtMM6hvPm2PNHp2RcmzBXcbi6C9WpkUhhFb8SVAr4CFrCsFxDg+oY6HalOjn8F+egyvhag==",
+      "dev": true,
       "requires": {
-        "browser-sync-ui": "v1.0.1",
+        "browser-sync-client": "^2.26.2",
+        "browser-sync-ui": "^2.26.2",
         "bs-recipes": "1.3.4",
-        "chokidar": "1.7.0",
+        "bs-snippet-injector": "^2.0.1",
+        "chokidar": "^2.0.4",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "^1.5.0",
+        "connect-history-api-fallback": "^1",
         "dev-ip": "^1.0.1",
-        "easy-extender": "2.3.2",
-        "eazy-logger": "3.0.2",
+        "easy-extender": "^2.3.4",
+        "eazy-logger": "^3",
         "etag": "^1.8.1",
         "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
-        "immutable": "3.8.2",
-        "localtunnel": "1.9.0",
+        "immutable": "^3",
+        "localtunnel": "1.9.1",
         "micromatch": "2.3.11",
-        "opn": "4.0.2",
+        "opn": "5.3.0",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
         "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
+        "send": "0.16.2",
         "serve-index": "1.9.1",
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
@@ -562,19 +584,11 @@
         "yargs": "6.4.0"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-          "requires": {
-            "micromatch": "^2.1.5",
-            "normalize-path": "^2.0.0"
-          }
-        },
         "arr-diff": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
@@ -582,12 +596,14 @@
         "array-unique": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -597,28 +613,14 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "chokidar": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-          "requires": {
-            "anymatch": "^1.3.0",
-            "async-each": "^1.0.0",
-            "fsevents": "^1.0.0",
-            "glob-parent": "^2.0.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^2.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0"
-          }
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -627,27 +629,22 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -656,6 +653,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -664,6 +662,7 @@
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -680,24 +679,17 @@
             "regex-cache": "^0.4.2"
           }
         },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-          "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "yargs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
             "cliui": "^3.2.0",
@@ -717,41 +709,75 @@
         },
         "yargs-parser": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0"
           }
         }
       }
     },
+    "browser-sync-client": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.2.tgz",
+      "integrity": "sha512-FEuVJD41fI24HJ30XOT2RyF5WcnEtdJhhTqeyDlnMk/8Ox9MZw109rvk9pdfRWye4soZLe+xcAo9tHSMxvgAdw==",
+      "dev": true,
+      "requires": {
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "mitt": "^1.1.3",
+        "rxjs": "^5.5.6"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        }
+      }
+    },
     "browser-sync-ui": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-      "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.2.tgz",
+      "integrity": "sha512-LF7GMWo8ELOE0eAlxuRCfnGQT1ZxKP9flCfGgZdXFc6BwmoqaJHlYe7MmVvykKkXjolRXTz8ztXAKGVqNwJ3EQ==",
+      "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "^1.1.0",
-        "immutable": "^3.7.6",
+        "connect-history-api-fallback": "^1",
+        "immutable": "^3",
         "server-destroy": "1.0.1",
-        "socket.io-client": "2.0.4",
+        "socket.io-client": "^2.0.4",
         "stream-throttle": "^0.1.3"
       }
     },
     "bs-recipes": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
+      "dev": true
+    },
+    "bs-snippet-injector": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+      "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -773,7 +799,8 @@
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
     },
     "camelcase": {
       "version": "4.1.0",
@@ -875,6 +902,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -884,7 +912,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -912,22 +941,26 @@
     "commander": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -938,22 +971,45 @@
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
         "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "connect-history-api-fallback": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+      "dev": true
+    },
+    "connect-logger": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/connect-logger/-/connect-logger-0.0.1.tgz",
+      "integrity": "sha1-TZmZeKHSC7RgjnzUNNdBZSJVF0s=",
+      "dev": true,
+      "requires": {
+        "moment": "*"
+      }
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -964,12 +1020,13 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coveralls": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-      "integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
+      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
       "dev": true,
       "requires": {
         "js-yaml": "^3.6.1",
@@ -1495,9 +1552,10 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1505,7 +1563,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1557,17 +1616,20 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "dev-ip": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
+      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -1576,17 +1638,19 @@
       "dev": true
     },
     "easy-extender": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
-      "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+      "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+      "dev": true,
       "requires": {
-        "lodash": "^3.10.1"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
         }
       }
     },
@@ -1594,6 +1658,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+      "dev": true,
       "requires": {
         "tfunk": "^3.0.1"
       }
@@ -1601,17 +1666,20 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
     "engine.io": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+      "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "1.0.0",
@@ -1619,22 +1687,13 @@
         "debug": "~3.1.0",
         "engine.io-parser": "~2.1.0",
         "ws": "~3.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "engine.io-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-      "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1647,27 +1706,18 @@
         "ws": "~3.3.1",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "engine.io-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
+        "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
     },
@@ -1675,6 +1725,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -1682,7 +1733,8 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1704,12 +1756,14 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
     },
     "eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
@@ -1780,6 +1834,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
       },
@@ -1788,6 +1843,7 @@
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
           "requires": {
             "is-number": "^2.1.0",
             "isobject": "^2.0.0",
@@ -1800,6 +1856,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -1808,6 +1865,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
           "requires": {
             "isarray": "1.0.0"
           }
@@ -1816,6 +1874,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1941,7 +2000,8 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1970,6 +2030,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -1978,12 +2039,24 @@
         "parseurl": "~1.3.2",
         "statuses": "~1.3.1",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "requires": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -1993,6 +2066,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -2000,32 +2074,25 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dev": true,
       "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "debug": "=3.1.0"
       }
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -2042,7 +2109,8 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -2083,6 +2151,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -2092,20 +2161,24 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -2114,11 +2187,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2127,28 +2202,34 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2157,21 +2238,25 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2180,11 +2265,13 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -2200,6 +2287,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2213,11 +2301,13 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -2226,6 +2316,7 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -2234,6 +2325,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -2242,16 +2334,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2259,22 +2354,26 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2283,6 +2382,7 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2291,6 +2391,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2298,11 +2399,13 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -2313,6 +2416,7 @@
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2330,6 +2434,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -2339,11 +2444,13 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2353,6 +2460,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -2363,16 +2471,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2380,16 +2491,19 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -2399,16 +2513,19 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -2420,6 +2537,7 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -2427,6 +2545,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2441,6 +2560,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -2448,36 +2568,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2487,6 +2614,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2495,6 +2623,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2502,11 +2631,13 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -2521,11 +2652,13 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -2533,18 +2666,21 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -2561,7 +2697,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2575,6 +2711,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -2584,6 +2721,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
           "requires": {
             "is-glob": "^2.0.0"
           }
@@ -2591,12 +2729,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2627,12 +2767,14 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -2641,6 +2783,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
       "requires": {
         "isarray": "2.0.1"
       },
@@ -2648,14 +2791,16 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -2697,12 +2842,14 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -2713,14 +2860,16 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
         }
       }
     },
     "http-proxy": {
       "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+      "dev": true,
       "requires": {
         "eventemitter3": "1.x.x",
         "requires-port": "1.x.x"
@@ -2737,12 +2886,14 @@
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -2805,7 +2956,8 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -2830,12 +2982,14 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -2843,12 +2997,14 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -2895,12 +3051,14 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -2908,7 +3066,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -2954,6 +3113,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "dev": true,
       "requires": {
         "lodash.isfinite": "^3.3.2"
       }
@@ -2987,12 +3147,14 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -3008,7 +3170,8 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3024,7 +3187,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -3058,7 +3222,7 @@
     "jasmine-spec-reporter": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
-      "integrity": "sha1-HWMq7ANBZwrTJPkrqEtLMrNeniI=",
+      "integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
       "dev": true,
       "requires": {
         "colors": "1.1.2"
@@ -3112,12 +3276,14 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -3125,2902 +3291,27 @@
     "limiter": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw=="
+      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
+      "dev": true
     },
     "lite-server": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lite-server/-/lite-server-2.3.0.tgz",
-      "integrity": "sha1-W0zI9dX9SDYQVICrKsSKOg3isMg=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lite-server/-/lite-server-2.4.0.tgz",
+      "integrity": "sha512-Vo06tHpXrqm37i6T7tVdq5PSbrFmvQRw64+dlFXdh1tltv6KCvpE+xzXz2+x6KWJ8ja+GgwSy4P13GUWyhaDHQ==",
+      "dev": true,
       "requires": {
-        "browser-sync": "^2.18.5",
+        "browser-sync": "^2.24.4",
         "connect-history-api-fallback": "^1.2.0",
         "connect-logger": "0.0.1",
         "lodash": "^4.11.1",
         "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "browser-sync": {
-          "version": "2.18.13",
-          "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.13.tgz",
-          "integrity": "sha1-wo3D6zvmfJepBwgrdyo3+RXBTX0=",
-          "requires": {
-            "browser-sync-client": "2.5.1",
-            "browser-sync-ui": "0.6.3",
-            "bs-recipes": "1.3.4",
-            "chokidar": "1.7.0",
-            "connect": "3.5.0",
-            "dev-ip": "^1.0.1",
-            "easy-extender": "2.3.2",
-            "eazy-logger": "3.0.2",
-            "emitter-steward": "^1.0.0",
-            "fs-extra": "3.0.1",
-            "http-proxy": "1.15.2",
-            "immutable": "3.8.1",
-            "localtunnel": "1.8.3",
-            "micromatch": "2.3.11",
-            "opn": "4.0.2",
-            "portscanner": "2.1.1",
-            "qs": "6.2.1",
-            "resp-modifier": "6.0.2",
-            "rx": "4.1.0",
-            "serve-index": "1.8.0",
-            "serve-static": "1.12.2",
-            "server-destroy": "1.0.1",
-            "socket.io": "1.6.0",
-            "socket.io-client": "1.6.0",
-            "ua-parser-js": "0.7.12",
-            "yargs": "6.4.0"
-          },
-          "dependencies": {
-            "browser-sync-client": {
-              "version": "2.5.1",
-              "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.5.1.tgz",
-              "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
-              "requires": {
-                "etag": "^1.7.0",
-                "fresh": "^0.3.0"
-              },
-              "dependencies": {
-                "etag": {
-                  "version": "1.8.1",
-                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-                  "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-                },
-                "fresh": {
-                  "version": "0.3.0",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-                  "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
-                }
-              }
-            },
-            "browser-sync-ui": {
-              "version": "0.6.3",
-              "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
-              "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
-              "requires": {
-                "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "^1.1.0",
-                "immutable": "^3.7.6",
-                "server-destroy": "1.0.1",
-                "stream-throttle": "^0.1.3",
-                "weinre": "^2.0.0-pre-I0Z7U9OV"
-              },
-              "dependencies": {
-                "async-each-series": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-                  "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
-                },
-                "stream-throttle": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-                  "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-                  "requires": {
-                    "commander": "^2.2.0",
-                    "limiter": "^1.0.5"
-                  },
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.12.2",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-                      "integrity": "sha1-D1lGxCftnsDZGka7ne9T5UZQ5VU="
-                    },
-                    "limiter": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
-                      "integrity": "sha1-Ip2AVYkcixGvng7lIA6OCbs9y+s="
-                    }
-                  }
-                },
-                "weinre": {
-                  "version": "2.0.0-pre-I0Z7U9OV",
-                  "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
-                  "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
-                  "requires": {
-                    "express": "2.5.x",
-                    "nopt": "3.0.x",
-                    "underscore": "1.7.x"
-                  },
-                  "dependencies": {
-                    "express": {
-                      "version": "2.5.11",
-                      "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-                      "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
-                      "requires": {
-                        "connect": "1.x",
-                        "mime": "1.2.4",
-                        "mkdirp": "0.3.0",
-                        "qs": "0.4.x"
-                      },
-                      "dependencies": {
-                        "connect": {
-                          "version": "1.9.2",
-                          "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
-                          "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
-                          "requires": {
-                            "formidable": "1.0.x",
-                            "mime": ">= 0.0.1",
-                            "qs": ">= 0.4.0"
-                          },
-                          "dependencies": {
-                            "formidable": {
-                              "version": "1.0.17",
-                              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-                              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
-                            }
-                          }
-                        },
-                        "mime": {
-                          "version": "1.2.4",
-                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
-                          "integrity": "sha1-EbX9rynCUJJVF2uArVIClPXekrc="
-                        },
-                        "mkdirp": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
-                        },
-                        "qs": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
-                          "integrity": "sha1-PKxMhh43GoycR3CsI82o3mObjl8="
-                        }
-                      }
-                    },
-                    "nopt": {
-                      "version": "3.0.6",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                      "requires": {
-                        "abbrev": "1"
-                      },
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                          "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
-                        }
-                      }
-                    },
-                    "underscore": {
-                      "version": "1.7.0",
-                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-                      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-                    }
-                  }
-                }
-              }
-            },
-            "bs-recipes": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-              "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
-            },
-            "chokidar": {
-              "version": "1.7.0",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-              "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-              "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
-              },
-              "dependencies": {
-                "anymatch": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-                  "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
-                  "requires": {
-                    "micromatch": "^2.1.5",
-                    "normalize-path": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "normalize-path": {
-                      "version": "2.1.1",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                      "requires": {
-                        "remove-trailing-separator": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "remove-trailing-separator": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-                          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-                  "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-                },
-                "glob-parent": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                  "requires": {
-                    "is-glob": "^2.0.0"
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "is-binary-path": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                  "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-                  "requires": {
-                    "binary-extensions": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "binary-extensions": {
-                      "version": "1.11.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-                      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-                    }
-                  }
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                  "requires": {
-                    "is-extglob": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                },
-                "readdirp": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-                  "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "minimatch": "^3.0.2",
-                    "readable-stream": "^2.0.2",
-                    "set-immediate-shim": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-                      "requires": {
-                        "brace-expansion": "^1.1.7"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                          "requires": {
-                            "balanced-match": "^1.0.0",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.3.3",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
-                      "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
-                        },
-                        "string_decoder": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-                          "requires": {
-                            "safe-buffer": "~5.1.0"
-                          }
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                        }
-                      }
-                    },
-                    "set-immediate-shim": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-                    }
-                  }
-                }
-              }
-            },
-            "connect": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-              "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
-              "requires": {
-                "debug": "~2.2.0",
-                "finalhandler": "0.5.0",
-                "parseurl": "~1.3.1",
-                "utils-merge": "1.0.0"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                  "requires": {
-                    "ms": "0.7.1"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                    }
-                  }
-                },
-                "finalhandler": {
-                  "version": "0.5.0",
-                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-                  "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
-                  "requires": {
-                    "debug": "~2.2.0",
-                    "escape-html": "~1.0.3",
-                    "on-finished": "~2.3.0",
-                    "statuses": "~1.3.0",
-                    "unpipe": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "escape-html": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-                      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-                    },
-                    "on-finished": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-                      "requires": {
-                        "ee-first": "1.1.1"
-                      },
-                      "dependencies": {
-                        "ee-first": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-                        }
-                      }
-                    },
-                    "statuses": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-                    },
-                    "unpipe": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-                      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-                    }
-                  }
-                },
-                "parseurl": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-                  "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-                },
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-                  "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
-                }
-              }
-            },
-            "dev-ip": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-              "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
-            },
-            "easy-extender": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
-              "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
-              "requires": {
-                "lodash": "^3.10.1"
-              },
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-                }
-              }
-            },
-            "eazy-logger": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-              "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-              "requires": {
-                "tfunk": "^3.0.1"
-              },
-              "dependencies": {
-                "tfunk": {
-                  "version": "3.1.0",
-                  "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-                  "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-                  "requires": {
-                    "chalk": "^1.1.1",
-                    "object-path": "^0.9.0"
-                  },
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                      "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                        }
-                      }
-                    },
-                    "object-path": {
-                      "version": "0.9.2",
-                      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-                      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
-                    }
-                  }
-                }
-              }
-            },
-            "emitter-steward": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
-              "integrity": "sha1-80Ea3pdYp1Zd+Eiy2gy70bRsvWQ="
-            },
-            "http-proxy": {
-              "version": "1.15.2",
-              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
-              "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-              "requires": {
-                "eventemitter3": "1.x.x",
-                "requires-port": "1.x.x"
-              },
-              "dependencies": {
-                "eventemitter3": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-                  "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
-                },
-                "requires-port": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-                  "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-                }
-              }
-            },
-            "immutable": {
-              "version": "3.8.1",
-              "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
-              "integrity": "sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI="
-            },
-            "localtunnel": {
-              "version": "1.8.3",
-              "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.3.tgz",
-              "integrity": "sha1-3MWSL9hWUQN9S94k/ZMkjQsk6wU=",
-              "requires": {
-                "debug": "2.6.8",
-                "openurl": "1.1.1",
-                "request": "2.81.0",
-                "yargs": "3.29.0"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.8",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                  "requires": {
-                    "ms": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                    }
-                  }
-                },
-                "openurl": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-                  "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
-                },
-                "request": {
-                  "version": "2.81.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                  "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-                  "requires": {
-                    "aws-sign2": "~0.6.0",
-                    "aws4": "^1.2.1",
-                    "caseless": "~0.12.0",
-                    "combined-stream": "~1.0.5",
-                    "extend": "~3.0.0",
-                    "forever-agent": "~0.6.1",
-                    "form-data": "~2.1.1",
-                    "har-validator": "~4.2.1",
-                    "hawk": "~3.1.3",
-                    "http-signature": "~1.1.0",
-                    "is-typedarray": "~1.0.0",
-                    "isstream": "~0.1.2",
-                    "json-stringify-safe": "~5.0.1",
-                    "mime-types": "~2.1.7",
-                    "oauth-sign": "~0.8.1",
-                    "performance-now": "^0.2.0",
-                    "qs": "~6.4.0",
-                    "safe-buffer": "^5.0.1",
-                    "stringstream": "~0.0.4",
-                    "tough-cookie": "~2.3.0",
-                    "tunnel-agent": "^0.6.0",
-                    "uuid": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-                    },
-                    "aws4": {
-                      "version": "1.6.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-                    },
-                    "caseless": {
-                      "version": "0.12.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                      "requires": {
-                        "delayed-stream": "~1.0.0"
-                      },
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                        }
-                      }
-                    },
-                    "extend": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-                    },
-                    "form-data": {
-                      "version": "2.1.4",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                      "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.5",
-                        "mime-types": "^2.1.12"
-                      },
-                      "dependencies": {
-                        "asynckit": {
-                          "version": "0.4.0",
-                          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-                        }
-                      }
-                    },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                      "requires": {
-                        "ajv": "^4.9.1",
-                        "har-schema": "^1.0.5"
-                      },
-                      "dependencies": {
-                        "ajv": {
-                          "version": "4.11.8",
-                          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                          "requires": {
-                            "co": "^4.6.0",
-                            "json-stable-stringify": "^1.0.1"
-                          },
-                          "dependencies": {
-                            "co": {
-                              "version": "4.6.0",
-                              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-                            },
-                            "json-stable-stringify": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-                              "requires": {
-                                "jsonify": "~0.0.0"
-                              },
-                              "dependencies": {
-                                "jsonify": {
-                                  "version": "0.0.0",
-                                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-                                  "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "har-schema": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-                        }
-                      }
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                      "requires": {
-                        "boom": "2.x.x",
-                        "cryptiles": "2.x.x",
-                        "hoek": "2.x.x",
-                        "sntp": "1.x.x"
-                      },
-                      "dependencies": {
-                        "boom": {
-                          "version": "2.10.1",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                          "requires": {
-                            "hoek": "2.x.x"
-                          }
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                          "requires": {
-                            "boom": "2.x.x"
-                          }
-                        },
-                        "hoek": {
-                          "version": "2.16.3",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                        },
-                        "sntp": {
-                          "version": "1.0.9",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                          "requires": {
-                            "hoek": "2.x.x"
-                          }
-                        }
-                      }
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                      "requires": {
-                        "assert-plus": "^0.2.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
-                      },
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-                        },
-                        "jsprim": {
-                          "version": "1.4.1",
-                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-                          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-                          "requires": {
-                            "assert-plus": "1.0.0",
-                            "extsprintf": "1.3.0",
-                            "json-schema": "0.2.3",
-                            "verror": "1.10.0"
-                          },
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                            },
-                            "extsprintf": {
-                              "version": "1.3.0",
-                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-                              "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-                            },
-                            "json-schema": {
-                              "version": "0.2.3",
-                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-                            },
-                            "verror": {
-                              "version": "1.10.0",
-                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-                              "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-                              "requires": {
-                                "assert-plus": "^1.0.0",
-                                "core-util-is": "1.0.2",
-                                "extsprintf": "^1.2.0"
-                              },
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.13.1",
-                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-                          "requires": {
-                            "asn1": "~0.2.3",
-                            "assert-plus": "^1.0.0",
-                            "bcrypt-pbkdf": "^1.0.0",
-                            "dashdash": "^1.12.0",
-                            "ecc-jsbn": "~0.1.1",
-                            "getpass": "^0.1.1",
-                            "jsbn": "~0.1.0",
-                            "tweetnacl": "~0.14.0"
-                          },
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3",
-                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-                            },
-                            "assert-plus": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                            },
-                            "bcrypt-pbkdf": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                              "optional": true,
-                              "requires": {
-                                "tweetnacl": "^0.14.3"
-                              }
-                            },
-                            "dashdash": {
-                              "version": "1.14.1",
-                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                              "requires": {
-                                "assert-plus": "^1.0.0"
-                              }
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1",
-                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                              "optional": true,
-                              "requires": {
-                                "jsbn": "~0.1.0"
-                              }
-                            },
-                            "getpass": {
-                              "version": "0.1.7",
-                              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                              "requires": {
-                                "assert-plus": "^1.0.0"
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.1",
-                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                              "optional": true
-                            },
-                            "tweetnacl": {
-                              "version": "0.14.5",
-                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                              "optional": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-                    },
-                    "mime-types": {
-                      "version": "2.1.17",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-                      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-                      "requires": {
-                        "mime-db": "~1.30.0"
-                      },
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.30.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-                          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-                    },
-                    "performance-now": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-                    },
-                    "qs": {
-                      "version": "6.4.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-                    },
-                    "tough-cookie": {
-                      "version": "2.3.3",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-                      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-                      "requires": {
-                        "punycode": "^1.4.1"
-                      },
-                      "dependencies": {
-                        "punycode": {
-                          "version": "1.4.1",
-                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-                        }
-                      }
-                    },
-                    "tunnel-agent": {
-                      "version": "0.6.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                      "requires": {
-                        "safe-buffer": "^5.0.1"
-                      }
-                    },
-                    "uuid": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-                      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
-                    }
-                  }
-                },
-                "yargs": {
-                  "version": "3.29.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
-                  "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
-                  "requires": {
-                    "camelcase": "^1.2.1",
-                    "cliui": "^3.0.3",
-                    "decamelize": "^1.0.0",
-                    "os-locale": "^1.4.0",
-                    "window-size": "^0.1.2",
-                    "y18n": "^3.2.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-                    },
-                    "cliui": {
-                      "version": "3.2.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                      "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "string-width": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                          "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
-                          },
-                          "dependencies": {
-                            "code-point-at": {
-                              "version": "1.1.0",
-                              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                            },
-                            "is-fullwidth-code-point": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                              "requires": {
-                                "number-is-nan": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                          "requires": {
-                            "ansi-regex": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                            }
-                          }
-                        },
-                        "wrap-ansi": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                          "requires": {
-                            "string-width": "^1.0.1",
-                            "strip-ansi": "^3.0.1"
-                          }
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-                    },
-                    "os-locale": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-                      "requires": {
-                        "lcid": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "lcid": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-                          "requires": {
-                            "invert-kv": "^1.0.0"
-                          },
-                          "dependencies": {
-                            "invert-kv": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "window-size": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-                      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-                    },
-                    "y18n": {
-                      "version": "3.2.1",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                    }
-                  }
-                }
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-              "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
-              },
-              "dependencies": {
-                "arr-diff": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                  "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                  "requires": {
-                    "arr-flatten": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "arr-flatten": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-                      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                  "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-                },
-                "braces": {
-                  "version": "1.8.5",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                  "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                  "requires": {
-                    "expand-range": "^1.8.1",
-                    "preserve": "^0.2.0",
-                    "repeat-element": "^1.1.2"
-                  },
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.2",
-                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-                      "requires": {
-                        "fill-range": "^2.1.0"
-                      },
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.3",
-                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-                          "requires": {
-                            "is-number": "^2.1.0",
-                            "isobject": "^2.0.0",
-                            "randomatic": "^1.1.3",
-                            "repeat-element": "^1.1.2",
-                            "repeat-string": "^1.5.2"
-                          },
-                          "dependencies": {
-                            "is-number": {
-                              "version": "2.1.0",
-                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                              "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                              "requires": {
-                                "kind-of": "^3.0.2"
-                              }
-                            },
-                            "isobject": {
-                              "version": "2.1.0",
-                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                              "requires": {
-                                "isarray": "1.0.0"
-                              },
-                              "dependencies": {
-                                "isarray": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                                }
-                              }
-                            },
-                            "randomatic": {
-                              "version": "1.1.7",
-                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                              "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
-                              "requires": {
-                                "is-number": "^3.0.0",
-                                "kind-of": "^4.0.0"
-                              },
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "3.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                                  "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                                  "requires": {
-                                    "kind-of": "^3.0.2"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.2.2",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                      "requires": {
-                                        "is-buffer": "^1.1.5"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.6",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-                                          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "kind-of": {
-                                  "version": "4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                                  "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                                  "requires": {
-                                    "is-buffer": "^1.1.5"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.6",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-                                      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                  "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                  "requires": {
-                    "is-posix-bracket": "^0.1.0"
-                  },
-                  "dependencies": {
-                    "is-posix-bracket": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-                    }
-                  }
-                },
-                "extglob": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                  "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                  "requires": {
-                    "is-extglob": "^1.0.0"
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-                  "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-                },
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                  "requires": {
-                    "is-extglob": "^1.0.0"
-                  }
-                },
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  },
-                  "dependencies": {
-                    "is-buffer": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-                      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
-                    }
-                  }
-                },
-                "normalize-path": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                  "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-                  "requires": {
-                    "remove-trailing-separator": "^1.0.1"
-                  },
-                  "dependencies": {
-                    "remove-trailing-separator": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-                      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-                    }
-                  }
-                },
-                "object.omit": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                  "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-                  "requires": {
-                    "for-own": "^0.1.4",
-                    "is-extendable": "^0.1.1"
-                  },
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.5",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-                      "requires": {
-                        "for-in": "^1.0.1"
-                      },
-                      "dependencies": {
-                        "for-in": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-                          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-                        }
-                      }
-                    },
-                    "is-extendable": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                  "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-                  "requires": {
-                    "glob-base": "^0.3.0",
-                    "is-dotfile": "^1.0.0",
-                    "is-extglob": "^1.0.0",
-                    "is-glob": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-                      "requires": {
-                        "glob-parent": "^2.0.0",
-                        "is-glob": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "glob-parent": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                          "requires": {
-                            "is-glob": "^2.0.0"
-                          }
-                        }
-                      }
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-                      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.4",
-                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-                  "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
-                  "requires": {
-                    "is-equal-shallow": "^0.1.3"
-                  },
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-                      "requires": {
-                        "is-primitive": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "is-primitive": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "opn": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-              "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-              "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-                },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "requires": {
-                    "pinkie": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                    }
-                  }
-                }
-              }
-            },
-            "portscanner": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-              "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-              "requires": {
-                "async": "1.5.2",
-                "is-number-like": "^1.0.3"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-                },
-                "is-number-like": {
-                  "version": "1.0.8",
-                  "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-                  "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
-                  "requires": {
-                    "lodash.isfinite": "^3.3.2"
-                  },
-                  "dependencies": {
-                    "lodash.isfinite": {
-                      "version": "3.3.2",
-                      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-                      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
-                    }
-                  }
-                }
-              }
-            },
-            "qs": {
-              "version": "6.2.1",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
-            },
-            "resp-modifier": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
-              "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-              "requires": {
-                "debug": "^2.2.0",
-                "minimatch": "^3.0.2"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.6.9",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                  "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-                  "requires": {
-                    "ms": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-                      "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "rx": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-              "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-            },
-            "serve-index": {
-              "version": "1.8.0",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-              "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
-              "requires": {
-                "accepts": "~1.3.3",
-                "batch": "0.5.3",
-                "debug": "~2.2.0",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.5.0",
-                "mime-types": "~2.1.11",
-                "parseurl": "~1.3.1"
-              },
-              "dependencies": {
-                "accepts": {
-                  "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-                  "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-                  "requires": {
-                    "mime-types": "~2.1.16",
-                    "negotiator": "0.6.1"
-                  },
-                  "dependencies": {
-                    "negotiator": {
-                      "version": "0.6.1",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-                      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-                    }
-                  }
-                },
-                "batch": {
-                  "version": "0.5.3",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-                  "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                  "requires": {
-                    "ms": "0.7.1"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                    }
-                  }
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-                  "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-                },
-                "http-errors": {
-                  "version": "1.5.1",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-                  "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "setprototypeof": "1.0.2",
-                    "statuses": ">= 1.3.1 < 2"
-                  },
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                    },
-                    "setprototypeof": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-                      "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
-                    },
-                    "statuses": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic="
-                    }
-                  }
-                },
-                "mime-types": {
-                  "version": "2.1.17",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-                  "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-                  "requires": {
-                    "mime-db": "~1.30.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.30.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-                      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-                    }
-                  }
-                },
-                "parseurl": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-                  "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.12.2",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz",
-              "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
-              "requires": {
-                "encodeurl": "~1.0.1",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.1",
-                "send": "0.15.2"
-              },
-              "dependencies": {
-                "encodeurl": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-                  "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-                  "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-                },
-                "parseurl": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-                  "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-                },
-                "send": {
-                  "version": "0.15.2",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.15.2.tgz",
-                  "integrity": "sha1-+R+rRAO8+H5xb3DOtdsvV4vcF9Y=",
-                  "requires": {
-                    "debug": "2.6.4",
-                    "depd": "~1.1.0",
-                    "destroy": "~1.0.4",
-                    "encodeurl": "~1.0.1",
-                    "escape-html": "~1.0.3",
-                    "etag": "~1.8.0",
-                    "fresh": "0.5.0",
-                    "http-errors": "~1.6.1",
-                    "mime": "1.3.4",
-                    "ms": "1.0.0",
-                    "on-finished": "~2.3.0",
-                    "range-parser": "~1.2.0",
-                    "statuses": "~1.3.1"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.6.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-                      "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-                      "requires": {
-                        "ms": "0.7.3"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.3",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-                          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
-                        }
-                      }
-                    },
-                    "depd": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-                    },
-                    "destroy": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-                      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-                    },
-                    "etag": {
-                      "version": "1.8.1",
-                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-                      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-                    },
-                    "fresh": {
-                      "version": "0.5.0",
-                      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-                      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
-                    },
-                    "http-errors": {
-                      "version": "1.6.2",
-                      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                      "requires": {
-                        "depd": "1.1.1",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.0.3",
-                        "statuses": ">= 1.3.1 < 2"
-                      },
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                        },
-                        "setprototypeof": {
-                          "version": "1.0.3",
-                          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.3.4",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-                      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
-                    },
-                    "ms": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-1.0.0.tgz",
-                      "integrity": "sha1-Wa3NIu3FQ/e1OBhi0xOHsfS8lHM="
-                    },
-                    "on-finished": {
-                      "version": "2.3.0",
-                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-                      "requires": {
-                        "ee-first": "1.1.1"
-                      },
-                      "dependencies": {
-                        "ee-first": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-                        }
-                      }
-                    },
-                    "range-parser": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-                      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-                    },
-                    "statuses": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-                      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-                    }
-                  }
-                }
-              }
-            },
-            "server-destroy": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-              "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
-            },
-            "socket.io": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
-              "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
-              "requires": {
-                "debug": "2.3.3",
-                "engine.io": "1.8.0",
-                "has-binary": "0.1.7",
-                "object-assign": "4.1.0",
-                "socket.io-adapter": "0.5.0",
-                "socket.io-client": "1.6.0",
-                "socket.io-parser": "2.3.1"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.3.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-                  "requires": {
-                    "ms": "0.7.2"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-                    }
-                  }
-                },
-                "engine.io": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
-                  "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
-                  "requires": {
-                    "accepts": "1.3.3",
-                    "base64id": "0.1.0",
-                    "cookie": "0.3.1",
-                    "debug": "2.3.3",
-                    "engine.io-parser": "1.3.1",
-                    "ws": "1.1.1"
-                  },
-                  "dependencies": {
-                    "accepts": {
-                      "version": "1.3.3",
-                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-                      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-                      "requires": {
-                        "mime-types": "~2.1.11",
-                        "negotiator": "0.6.1"
-                      },
-                      "dependencies": {
-                        "mime-types": {
-                          "version": "2.1.17",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-                          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-                          "requires": {
-                            "mime-db": "~1.30.0"
-                          },
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.30.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-                              "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-                            }
-                          }
-                        },
-                        "negotiator": {
-                          "version": "0.6.1",
-                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-                          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-                        }
-                      }
-                    },
-                    "base64id": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-                      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
-                    },
-                    "cookie": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-                      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-                    },
-                    "engine.io-parser": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
-                      "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
-                      "requires": {
-                        "after": "0.8.1",
-                        "arraybuffer.slice": "0.0.6",
-                        "base64-arraybuffer": "0.1.5",
-                        "blob": "0.0.4",
-                        "has-binary": "0.1.6",
-                        "wtf-8": "1.0.0"
-                      },
-                      "dependencies": {
-                        "after": {
-                          "version": "0.8.1",
-                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-                          "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
-                        },
-                        "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-                          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
-                        },
-                        "base64-arraybuffer": {
-                          "version": "0.1.5",
-                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-                          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-                        },
-                        "blob": {
-                          "version": "0.0.4",
-                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-                          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
-                        },
-                        "has-binary": {
-                          "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-                          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-                          "requires": {
-                            "isarray": "0.0.1"
-                          },
-                          "dependencies": {
-                            "isarray": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                            }
-                          }
-                        },
-                        "wtf-8": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
-                          "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-                      "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-                      "requires": {
-                        "options": ">=0.0.5",
-                        "ultron": "1.0.x"
-                      },
-                      "dependencies": {
-                        "options": {
-                          "version": "0.0.6",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-                          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-                        },
-                        "ultron": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-                          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-                        }
-                      }
-                    }
-                  }
-                },
-                "has-binary": {
-                  "version": "0.1.7",
-                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-                  "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-                  "requires": {
-                    "isarray": "0.0.1"
-                  },
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-                },
-                "socket.io-adapter": {
-                  "version": "0.5.0",
-                  "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
-                  "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-                  "requires": {
-                    "debug": "2.3.3",
-                    "socket.io-parser": "2.3.1"
-                  }
-                },
-                "socket.io-parser": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-                  "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-                  "requires": {
-                    "component-emitter": "1.1.2",
-                    "debug": "2.2.0",
-                    "isarray": "0.0.1",
-                    "json3": "3.3.2"
-                  },
-                  "dependencies": {
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                      "requires": {
-                        "ms": "0.7.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                        }
-                      }
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                    },
-                    "json3": {
-                      "version": "3.3.2",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-                    }
-                  }
-                }
-              }
-            },
-            "socket.io-client": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
-              "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
-              "requires": {
-                "backo2": "1.0.2",
-                "component-bind": "1.0.0",
-                "component-emitter": "1.2.1",
-                "debug": "2.3.3",
-                "engine.io-client": "1.8.0",
-                "has-binary": "0.1.7",
-                "indexof": "0.0.1",
-                "object-component": "0.0.3",
-                "parseuri": "0.0.5",
-                "socket.io-parser": "2.3.1",
-                "to-array": "0.1.4"
-              },
-              "dependencies": {
-                "backo2": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-                  "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-                },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-                  "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-                },
-                "component-emitter": {
-                  "version": "1.2.1",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-                  "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-                },
-                "debug": {
-                  "version": "2.3.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-                  "requires": {
-                    "ms": "0.7.2"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-                    }
-                  }
-                },
-                "engine.io-client": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
-                  "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
-                  "requires": {
-                    "component-emitter": "1.2.1",
-                    "component-inherit": "0.0.3",
-                    "debug": "2.3.3",
-                    "engine.io-parser": "1.3.1",
-                    "has-cors": "1.1.0",
-                    "indexof": "0.0.1",
-                    "parsejson": "0.0.3",
-                    "parseqs": "0.0.5",
-                    "parseuri": "0.0.5",
-                    "ws": "1.1.1",
-                    "xmlhttprequest-ssl": "1.5.3",
-                    "yeast": "0.1.2"
-                  },
-                  "dependencies": {
-                    "component-inherit": {
-                      "version": "0.0.3",
-                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-                      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-                    },
-                    "engine.io-parser": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
-                      "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
-                      "requires": {
-                        "after": "0.8.1",
-                        "arraybuffer.slice": "0.0.6",
-                        "base64-arraybuffer": "0.1.5",
-                        "blob": "0.0.4",
-                        "has-binary": "0.1.6",
-                        "wtf-8": "1.0.0"
-                      },
-                      "dependencies": {
-                        "after": {
-                          "version": "0.8.1",
-                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-                          "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
-                        },
-                        "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-                          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
-                        },
-                        "base64-arraybuffer": {
-                          "version": "0.1.5",
-                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-                          "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-                        },
-                        "blob": {
-                          "version": "0.0.4",
-                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-                          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
-                        },
-                        "has-binary": {
-                          "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-                          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-                          "requires": {
-                            "isarray": "0.0.1"
-                          },
-                          "dependencies": {
-                            "isarray": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                            }
-                          }
-                        },
-                        "wtf-8": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
-                          "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
-                        }
-                      }
-                    },
-                    "has-cors": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-                      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-                    },
-                    "parsejson": {
-                      "version": "0.0.3",
-                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-                      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-                      "requires": {
-                        "better-assert": "~1.0.0"
-                      },
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-                          "requires": {
-                            "callsite": "1.0.0"
-                          },
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                              "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseqs": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-                      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-                      "requires": {
-                        "better-assert": "~1.0.0"
-                      },
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-                          "requires": {
-                            "callsite": "1.0.0"
-                          },
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                              "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "1.1.1",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-                      "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-                      "requires": {
-                        "options": ">=0.0.5",
-                        "ultron": "1.0.x"
-                      },
-                      "dependencies": {
-                        "options": {
-                          "version": "0.0.6",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-                          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-                        },
-                        "ultron": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-                          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-                        }
-                      }
-                    },
-                    "xmlhttprequest-ssl": {
-                      "version": "1.5.3",
-                      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-                      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
-                    },
-                    "yeast": {
-                      "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-                      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-                    }
-                  }
-                },
-                "has-binary": {
-                  "version": "0.1.7",
-                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-                  "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-                  "requires": {
-                    "isarray": "0.0.1"
-                  },
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                    }
-                  }
-                },
-                "indexof": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-                  "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-                  "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-                },
-                "parseuri": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-                  "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-                  "requires": {
-                    "better-assert": "~1.0.0"
-                  },
-                  "dependencies": {
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-                      "requires": {
-                        "callsite": "1.0.0"
-                      },
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                          "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-                        }
-                      }
-                    }
-                  }
-                },
-                "socket.io-parser": {
-                  "version": "2.3.1",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-                  "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-                  "requires": {
-                    "component-emitter": "1.1.2",
-                    "debug": "2.2.0",
-                    "isarray": "0.0.1",
-                    "json3": "3.3.2"
-                  },
-                  "dependencies": {
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                      "requires": {
-                        "ms": "0.7.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-                        }
-                      }
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                    },
-                    "json3": {
-                      "version": "3.3.2",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-                    }
-                  }
-                },
-                "to-array": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-                  "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-                }
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-              "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
-            },
-            "yargs": {
-              "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
-              "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
-              "requires": {
-                "camelcase": "^3.0.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^1.4.0",
-                "read-pkg-up": "^1.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^1.0.2",
-                "which-module": "^1.0.0",
-                "window-size": "^0.2.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^4.1.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                  "requires": {
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wrap-ansi": "^2.0.0"
-                  },
-                  "dependencies": {
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                      "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-                },
-                "os-locale": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                  "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-                  "requires": {
-                    "lcid": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "lcid": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-                      "requires": {
-                        "invert-kv": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                  "requires": {
-                    "find-up": "^1.0.0",
-                    "read-pkg": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                      "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                          "requires": {
-                            "pinkie-promise": "^2.0.0"
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                          "requires": {
-                            "pinkie": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                      "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                          "requires": {
-                            "graceful-fs": "^4.1.2",
-                            "parse-json": "^2.2.0",
-                            "pify": "^2.0.0",
-                            "pinkie-promise": "^2.0.0",
-                            "strip-bom": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                              "requires": {
-                                "error-ex": "^1.2.0"
-                              },
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                                  "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-                                  "requires": {
-                                    "is-arrayish": "^0.2.1"
-                                  },
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                              "requires": {
-                                "pinkie": "^2.0.0"
-                              },
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                              "requires": {
-                                "is-utf8": "^0.2.0"
-                              },
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "normalize-package-data": {
-                          "version": "2.4.0",
-                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-                          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-                          "requires": {
-                            "hosted-git-info": "^2.1.4",
-                            "is-builtin-module": "^1.0.0",
-                            "semver": "2 || 3 || 4 || 5",
-                            "validate-npm-package-license": "^3.0.1"
-                          },
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.5.0",
-                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-                              "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-                              "requires": {
-                                "builtin-modules": "^1.0.0"
-                              },
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.1",
-                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-                                }
-                              }
-                            },
-                            "semver": {
-                              "version": "5.4.1",
-                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-                              "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-                              "requires": {
-                                "spdx-correct": "~1.0.0",
-                                "spdx-expression-parse": "~1.0.0"
-                              },
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-                                  "requires": {
-                                    "spdx-license-ids": "^1.0.2"
-                                  },
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.2.2",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-                                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.4",
-                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-                                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                          "requires": {
-                            "graceful-fs": "^4.1.2",
-                            "pify": "^2.0.0",
-                            "pinkie-promise": "^2.0.0"
-                          },
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                              "requires": {
-                                "pinkie": "^2.0.0"
-                              },
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "requires": {
-                        "number-is-nan": "^1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "requires": {
-                        "ansi-regex": "^2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                        }
-                      }
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                  "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-                },
-                "window-size": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-                  "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                },
-                "yargs-parser": {
-                  "version": "4.2.1",
-                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-                  "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-                  "requires": {
-                    "camelcase": "^3.0.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "connect-history-api-fallback": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-          "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
-        },
-        "connect-logger": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/connect-logger/-/connect-logger-0.0.1.tgz",
-          "integrity": "sha1-TZmZeKHSC7RgjnzUNNdBZSJVF0s=",
-          "requires": {
-            "moment": "*"
-          },
-          "dependencies": {
-            "moment": {
-              "version": "2.19.2",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-              "integrity": "sha1-in93TJWmRVC0x+vUlmg5CPlBnb4="
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -6030,12 +3321,13 @@
       }
     },
     "localtunnel": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-      "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.1.tgz",
+      "integrity": "sha512-HWrhOslklDvxgOGFLxi6fQVnvpl6XdX4sPscfqMZkzi3gtt9V7LKBWYvNUcpHSVvjwCQ6xzXacVvICNbNcyPnQ==",
+      "dev": true,
       "requires": {
         "axios": "0.17.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "openurl": "1.1.1",
         "yargs": "6.6.0"
       },
@@ -6043,12 +3335,14 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6056,12 +3350,14 @@
         "which-module": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
             "cliui": "^3.2.0",
@@ -6080,8 +3376,9 @@
         },
         "yargs-parser": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "dev": true,
           "requires": {
             "camelcase": "^3.0.0"
           }
@@ -6112,7 +3409,8 @@
     "lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -6142,7 +3440,8 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -6177,19 +3476,22 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
     },
     "mime-db": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
     },
     "mime-types": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
@@ -6200,10 +3502,22 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mitt": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.3.tgz",
+      "integrity": "sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA==",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -6226,10 +3540,17 @@
         }
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -6240,6 +3561,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -6265,12 +3587,14 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -6282,6 +3606,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -6298,7 +3623,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "11.6.0",
@@ -9417,15 +6743,11 @@
         }
       }
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-component": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -9461,7 +6783,8 @@
     "object-path": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
+      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -9476,6 +6799,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
@@ -9494,6 +6818,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -9517,7 +6842,8 @@
     "openurl": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
+      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
+      "dev": true
     },
     "opn": {
       "version": "5.3.0",
@@ -9529,8 +6855,9 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -9574,6 +6901,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -9584,12 +6912,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -9600,6 +6930,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -9608,6 +6939,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -9616,6 +6948,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -9623,7 +6956,8 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -9663,6 +6997,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -9671,18 +7006,21 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -9691,6 +7029,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "dev": true,
       "requires": {
         "async": "1.5.2",
         "is-number-like": "^1.0.3"
@@ -9705,12 +7044,14 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -9721,12 +7062,14 @@
     "qs": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+      "dev": true
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -9736,19 +7079,22 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         }
       }
     },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
     },
     "raw-body": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
       "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.3",
@@ -9760,6 +7106,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -9770,6 +7117,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -9779,6 +7127,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9793,6 +7142,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "minimatch": "^3.0.2",
@@ -9804,6 +7154,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
@@ -9821,32 +7172,38 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.6.0",
@@ -9866,9 +7223,21 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+      "dev": true,
       "requires": {
         "debug": "^2.2.0",
         "minimatch": "^3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "restore-cursor": {
@@ -9897,7 +7266,8 @@
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
     },
     "rxjs": {
       "version": "6.2.1",
@@ -9910,7 +7280,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -9929,12 +7300,14 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -9951,10 +7324,20 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
         }
       }
     },
@@ -9962,6 +7345,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -9970,12 +7354,24 @@
         "http-errors": "~1.6.2",
         "mime-types": "~2.1.17",
         "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -9986,17 +7382,20 @@
     "server-destroy": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.0",
@@ -10024,7 +7423,8 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -10054,7 +7454,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -10289,6 +7689,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "dev": true,
       "requires": {
         "debug": "~3.1.0",
         "engine.io": "~3.2.0",
@@ -10296,120 +7697,52 @@
         "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
         "socket.io-parser": "~3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "engine.io-client": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-          "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
-          "requires": {
-            "component-emitter": "1.2.1",
-            "component-inherit": "0.0.3",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.1.1",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
-            "yeast": "0.1.2"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "socket.io-client": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-          "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
-          "requires": {
-            "backo2": "1.0.2",
-            "base64-arraybuffer": "0.1.5",
-            "component-bind": "1.0.0",
-            "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
-            "engine.io-client": "~3.2.0",
-            "has-binary2": "~1.0.2",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "object-component": "0.0.3",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "socket.io-parser": "~3.2.0",
-            "to-array": "0.1.4"
-          }
-        },
-        "socket.io-parser": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-          "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-          "requires": {
-            "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
-            "isarray": "2.0.1"
-          }
-        }
       }
     },
     "socket.io-adapter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+      "dev": true
     },
     "socket.io-client": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "dev": true,
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "~3.2.0",
         "to-array": "0.1.4"
       }
     },
     "socket.io-parser": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-      "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
@@ -10448,32 +7781,36 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -10514,12 +7851,14 @@
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
     },
     "stream-throttle": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "dev": true,
       "requires": {
         "commander": "^2.2.0",
         "limiter": "^1.0.5"
@@ -10529,6 +7868,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -10539,6 +7879,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10549,6 +7890,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -10557,6 +7899,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -10565,6 +7908,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
       }
@@ -10578,12 +7922,20 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
     },
     "tfunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.1",
         "object-path": "^0.9.0"
@@ -10591,8 +7943,9 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -10689,7 +8042,8 @@
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -10795,7 +8149,7 @@
         "source-map-support": {
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
             "source-map": "^0.5.6"
@@ -11027,12 +8381,14 @@
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
     },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",
@@ -11072,7 +8428,8 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -11155,17 +8512,20 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -11189,12 +8549,14 @@
     "window-size": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -11203,12 +8565,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           },
@@ -11216,7 +8580,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "dev": true
             }
           }
         },
@@ -11224,6 +8589,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11233,7 +8599,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "dev": true
             }
           }
         },
@@ -11241,6 +8608,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11256,6 +8624,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",
         "safe-buffer": "~5.1.0",
@@ -11265,12 +8634,14 @@
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -11384,7 +8755,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
             "lcid": "^1.0.0",
@@ -11821,7 +9192,8 @@
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,14 +78,12 @@
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",
     "inquirer": "^6.0.0",
-    "lite-server": "^2.3.0",
     "opn": "^5.3.0",
     "resolve": "^1.6.0",
     "shelljs": "^0.7.8",
     "through2": "^2.0.3",
     "typescript": "^2.8.1",
-    "yargs": "^8.0.2",
-    "browser-sync": "2.24.5"
+    "yargs": "^8.0.2"
   },
   "devDependencies": {
     "@angular-devkit/schematics": "^0.6.8",
@@ -94,9 +92,11 @@
     "@types/jasmine": "^2.8.6",
     "@types/node": "^8.10.0",
     "@types/shelljs": "^0.7.8",
+    "browser-sync": "^2.26.3",
     "coveralls": "^3.0.0",
     "jasmine": "^2.99.0",
     "jasmine-spec-reporter": "^4.2.1",
+    "lite-server": "^2.4.0",
     "nyc": "^11.6.0",
     "source-map-support": "^0.5.4",
     "ts-node": "^3.3.0",

--- a/spec/jasmine-runner.ts
+++ b/spec/jasmine-runner.ts
@@ -1,4 +1,3 @@
-// tslint:disable:no-implicit-dependencies
 import Jasmine = require("jasmine");
 import { DisplayProcessor, SpecReporter } from "jasmine-spec-reporter";
 

--- a/spec/tslint.json
+++ b/spec/tslint.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../tslint.json",
+	"rules": {
+		"no-implicit-dependencies": [true, "dev"]
+	}
+}

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -21,7 +21,7 @@ describe("Unit - Package Manager", () => {
 				}
 			}
 		});
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			igPackageRegistry: "trial",
 			project: {
 				components: ["igGrid", "igExcel"],
@@ -95,7 +95,7 @@ describe("Unit - Package Manager", () => {
 				}
 			}
 		});
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			igPackageRegistry: "trial",
 			project: {
 				components: ["igGrid", "igExcel"],
@@ -112,7 +112,7 @@ describe("Unit - Package Manager", () => {
 		spyOn(Util, "log");
 		spyOn(PackageManager, "removePackage");
 		PackageManager.ensureIgniteUISource(true, mockTemplateMgr, true);
-		expect(ProjectConfig.getConfig).toHaveBeenCalled();
+		expect(ProjectConfig.localConfig).toHaveBeenCalled();
 		expect(Util.log).toHaveBeenCalledTimes(7);
 		expect(Util.log).toHaveBeenCalledWith(
 			"The project you've created requires the full version of Ignite UI from Infragistics private feed.",
@@ -168,7 +168,7 @@ describe("Unit - Package Manager", () => {
 				}
 			}
 		});
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			igPackageRegistry: "trial",
 			project: {
 				components: ["igGrid", "igExcel"],
@@ -177,7 +177,7 @@ describe("Unit - Package Manager", () => {
 			}
 		});
 		PackageManager.ensureIgniteUISource(false, mockTemplateMgr, true);
-		expect(ProjectConfig.getConfig).toHaveBeenCalled();
+		expect(ProjectConfig.localConfig).toHaveBeenCalled();
 		expect(Util.log).toHaveBeenCalledWith(
 		"Template(s) that require the full version of Ignite UI found in the project." +
 		"You'll might be prompted for credentials on build to install it.", "yellow");
@@ -201,7 +201,7 @@ describe("Unit - Package Manager", () => {
 				}
 			}
 		});
-		spyOn(ProjectConfig, "getConfig").and.callFake(() => {
+		spyOn(ProjectConfig, "localConfig").and.callFake(() => {
 			return {
 				project: {
 					components: ["igGrid", "igExcel"],
@@ -244,8 +244,7 @@ describe("Unit - Package Manager", () => {
 	});
 
 	it("Should run installPackages properly with error code", async done => {
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
-			disableAnalytics: false,
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false
 		});
 		spyOn(Util, "log");
@@ -256,34 +255,33 @@ describe("Unit - Package Manager", () => {
 		});
 		spyOn(ProjectConfig, "setConfig");
 		await PackageManager.installPackages(true);
-		expect(ProjectConfig.getConfig).toHaveBeenCalledTimes(1);
+		expect(ProjectConfig.localConfig).toHaveBeenCalledTimes(1);
 		expect(Util.log).toHaveBeenCalledTimes(3);
 		expect(Util.log).toHaveBeenCalledWith(`Installing npm packages`);
 		expect(Util.log).toHaveBeenCalledWith(`Error installing npm packages.`);
 		expect(Util.log).toHaveBeenCalledWith(`Example`);
 		expect(cp.execSync).toHaveBeenCalledWith(`npm install --quiet`, { stdio: "pipe", killSignal: "SIGINT" });
-		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({disableAnalytics: false, packagesInstalled: true});
+		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ packagesInstalled: true});
 		done();
 	});
 	it("Should run installPackages properly without error code", async done => {
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
-			disableAnalytics: true,
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false
 		});
 		spyOn(Util, "log");
 		spyOn(cp, "execSync").and.returnValue("");
 		spyOn(ProjectConfig, "setConfig");
 		await PackageManager.installPackages(true);
-		expect(ProjectConfig.getConfig).toHaveBeenCalledTimes(1);
+		expect(ProjectConfig.localConfig).toHaveBeenCalledTimes(1);
 		expect(Util.log).toHaveBeenCalledTimes(2);
 		expect(Util.log).toHaveBeenCalledWith(`Installing npm packages`);
 		expect(Util.log).toHaveBeenCalledWith(`Packages installed successfully`);
 		expect(cp.execSync).toHaveBeenCalledWith(`npm install --quiet`, { stdio: "pipe", killSignal: "SIGINT" });
-		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({disableAnalytics: true, packagesInstalled: true});
+		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ packagesInstalled: true});
 		done();
 	});
 	it("Should exit on installPackages if child install is terminated", async done => {
-		spyOn(ProjectConfig, "getConfig").and.returnValue({
+		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false,
 			skipAnalytic: true
 		});

--- a/spec/unit/quickstart-spec.ts
+++ b/spec/unit/quickstart-spec.ts
@@ -46,8 +46,10 @@ describe("Unit - Quickstart command", () => {
 	});
 
 	it("Creates default jquery quickstart when no framework is specified", async done => {
+		spyOn(shell, "exec");
 		spyOn(liteServer, "server");
 		await quickstartCmd.execute({ framework: "jquery" });
+		expect(shell.exec).toHaveBeenCalledWith("npm install");
 		const outDir = path.join(process.cwd(), "jquery-quickstart");
 		const quickStartFiles = path.join(__dirname, "../../templates/quickstart", "jquery");
 

--- a/templates/angular/igx-ts/projects/empty/files/src/app/app.component.html
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/app.component.html
@@ -5,7 +5,7 @@
       <span *ngFor="let route of topNavLinks" igxDrawerItem igxRipple routerLinkActive="igx-nav-drawer__item--active" routerLink="{{route.path}}">{{route.name}}</span>
     </ng-template>
   </igx-nav-drawer>
-  <div  class="main" igxFlex igxLayout igxLayoutDir="columns">
+  <div igxFlex igxLayout igxLayoutDir="columns">
     <igx-navbar title="$(name)" actionButtonIcon="menu" (onAction)="nav.toggle()"></igx-navbar>
     <div class="content" igxFlex>
       <router-outlet></router-outlet>

--- a/templates/angular/igx-ts/projects/empty/files/src/app/app.component.scss
+++ b/templates/angular/igx-ts/projects/empty/files/src/app/app.component.scss
@@ -1,5 +1,6 @@
-.main {
-  width: 100%;
+
+:host > div {
+  height: 100%;
 }
 
 .content {

--- a/templates/angular/igx-ts/projects/empty/files/src/styles.scss
+++ b/templates/angular/igx-ts/projects/empty/files/src/styles.scss
@@ -1,5 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 $(CustomTheme)
+html, body {
+  height: 100%;
+}
 .content p {
   margin: 15px;
 }

--- a/templates/jquery/js/projects/empty/files/package.json
+++ b/templates/jquery/js/projects/empty/files/package.json
@@ -10,6 +10,7 @@
     "ignite-ui": "~18.1"
   },
   "devDependencies": {
+    "browser-sync": "^2.26.3",
     "igniteui-cli": "^$(cliVersion)",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/templates/quickstart/angular/package.json
+++ b/templates/quickstart/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-quickstart",
   "version": "1.0.0",
-  "description": "QuickStart package.json",
+  "description": "Ignite UI for JavaScript Angular Wrappers quick start",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",
     "lint": "tslint ./app/**/*.ts -t verbose",
@@ -12,12 +12,6 @@
   },
   "keywords": [],
   "author": "",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/angular/angular.io/blob/master/LICENSE"
-    }
-  ],
   "dependencies": {
     "@angular/common": "^5.2.0",
     "@angular/compiler": "^5.2.0",

--- a/templates/quickstart/jquery/package.json
+++ b/templates/quickstart/jquery/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "igniteui-jquery-quickstart",
+  "version": "1.0.0",
+  "description": "Ignite UI for JavaScript quick start",
+  "keywords": [],
+  "author": "",
+  "dependencies": {},
+  "devDependencies": {
+    "lite-server": "^2.4.0"
+  },
+  "repository": {}
+}

--- a/templates/quickstart/react/package.json
+++ b/templates/quickstart/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ignite-ui-cli",
   "version": "1.0.0",
-  "description": "Cli for installing Ignite UI templates",
+  "description": "Ignite UI for JavaScript React Wrappers quick start",
   "keywords": [
     "CLI",
     "Ignite UI"


### PR DESCRIPTION
- Adjust Ignite UI for Angular project content height
- In Ignite UI for JavaScript projects when upgrading to full package, respect the installed version range
- General: Drop lite-server/browser-sync as package dependencies (moved to dev) so those are not installed with the igniteui-cli package, but rather in the projects that need them.
