### PR TITLE
feat(igr): add financial chart template to igr-es6 templates

### DIFF
--- a/templates/react/igr-es6/bullet-graph/default/index.ts
+++ b/templates/react/igr-es6/bullet-graph/default/index.ts
@@ -10,7 +10,7 @@ class IgrBulletGraphTemplate extends IgniteUIForReactTemplate {
 		this.projectType = "igr-es6";
 		this.name = "Bullet Graph";
 		this.description = `allows for a linear and concise view of measures compared against a scale.`;
-		this.packages = ["igniteui-react-gauges@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-gauges@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrBulletGraphTemplate();

--- a/templates/react/igr-es6/category-chart/default/index.ts
+++ b/templates/react/igr-es6/category-chart/default/index.ts
@@ -11,7 +11,7 @@ class IgrCategoryChartTemplate extends IgniteUIForReactTemplate {
 		this.name = "Category Chart";
 		this.description = `makes visualizing category data easy. Simplifies the complexities
 							of the data visualization domain into manageable API`;
-		this.packages = ["igniteui-react-charts@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-charts@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrCategoryChartTemplate();

--- a/templates/react/igr-es6/doughnut-chart/default/index.ts
+++ b/templates/react/igr-es6/doughnut-chart/default/index.ts
@@ -10,7 +10,7 @@ class IgrDoughnutChartTemplate extends IgniteUIForReactTemplate {
 		this.projectType = "igr-es6";
 		this.name = "Doughnut Chart";
 		this.description = `proportionally illustrate the occurrences of variables.`;
-		this.packages = ["igniteui-react-charts@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-charts@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrDoughnutChartTemplate();

--- a/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/index.js
+++ b/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/index.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react'
+import { IgrFinancialChartModule } from 'igniteui-react-charts/ES5/igr-financial-chart-module';
+import { IgrFinancialChart } from 'igniteui-react-charts/ES5/igr-financial-chart';
+import style from './style.css';
+
+IgrFinancialChartModule.register();
+
+const data = [
+    { time: new Date(2013, 1, 1), open: 268.93, high: 268.93, low: 262.80, close: 265.00, volume: 6118146 },
+    { time: new Date(2013, 1, 4), open: 262.78, high: 264.68, low: 259.07, close: 259.98, volume: 3723793 },
+    { time: new Date(2013, 1, 5), open: 262.00, high: 268.03, low: 261.46, close: 266.89, volume: 4013780 },
+    { time: new Date(2013, 1, 6), open: 265.16, high: 266.89, low: 261.11, close: 262.22, volume: 2772204 },
+    { time: new Date(2013, 1, 7), open: 264.10, high: 264.10, low: 255.11, close: 260.23, volume: 3977065 },
+    { time: new Date(2013, 1, 8), open: 261.40, high: 265.25, low: 260.56, close: 261.95, volume: 3879628 },
+    { time: new Date(2013, 1, 11), open: 263.20, high: 263.25, low: 256.60, close: 257.21, volume: 3407457 },
+    { time: new Date(2013, 1, 12), open: 259.19, high: 260.16, low: 257.00, close: 258.70, volume: 2944730 },
+    { time: new Date(2013, 1, 13), open: 261.53, high: 269.96, low: 260.30, close: 269.47, volume: 5295786 },
+    { time: new Date(2013, 1, 14), open: 267.37, high: 270.65, low: 265.40, close: 269.24, volume: 3464080 },
+    { time: new Date(2013, 1, 15), open: 267.63, high: 268.92, low: 263.11, close: 265.09, volume: 3981233 }
+];
+
+
+export default class $(ClassName) extends Component {
+    title = 'Financial Chart';
+    state = {
+        data: []
+    }
+
+    componentWillMount() {
+        this.setState({
+            data
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                <h1 className={style.title}>{this.title}</h1>
+                <div>
+                    Read more on the&nbsp;
+                    <a href="https://www.infragistics.com/products/ignite-ui-react/react/components/financialchart.html">
+                        official documentation page
+                    </a>
+                </div>
+                <div className={style.container}>
+                    <IgrFinancialChart
+                        width="700px"
+                        height="500px"
+                        dataSource={this.state.data}>
+                    </IgrFinancialChart>
+                </div>
+            </div >
+        )
+    }
+}

--- a/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/style.css
+++ b/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/style.css
@@ -1,0 +1,10 @@
+:local(.container) {
+    padding-top: 24px;
+    display: flex;
+    flex-flow: row;
+	justify-content: center;
+	text-align: left;
+}
+:local(.title) {
+    color: rgb(0, 153, 255);
+}

--- a/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/test.js
+++ b/templates/react/igr-es6/financial-chart/default/files/src/views/__path__/test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import $(ClassName) from './index';
+
+// won't run https://github.com/facebook/create-react-app/issues/6020
+// TODO: see if template can 
+
+it('$(ClassName) renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<$(ClassName) />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});

--- a/templates/react/igr-es6/financial-chart/default/index.ts
+++ b/templates/react/igr-es6/financial-chart/default/index.ts
@@ -1,0 +1,18 @@
+import { IgniteUIForReactTemplate } from "../../../../../lib/templates/IgniteUIForReactTemplate";
+
+class IgrFinancialChartTemplate extends IgniteUIForReactTemplate {
+	constructor() {
+		super(__dirname);
+		this.components = ["Financial Chart"];
+		this.controlGroup = "Charts";
+		// set to true once bug with chart destoy is fixed
+		this.listInComponentTemplates = false;
+		this.id = "financial-chart";
+		this.projectType = "igr-es6";
+		this.name = "Financial Chart";
+		this.description = `charting component that makes it easy to visualize financial data by
+							using a simple and intuitive API.`;
+		this.packages = ["igniteui-react-charts@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+	}
+}
+module.exports = new IgrFinancialChartTemplate();

--- a/templates/react/igr-es6/financial-chart/default/index.ts
+++ b/templates/react/igr-es6/financial-chart/default/index.ts
@@ -12,7 +12,7 @@ class IgrFinancialChartTemplate extends IgniteUIForReactTemplate {
 		this.name = "Financial Chart";
 		this.description = `charting component that makes it easy to visualize financial data by
 							using a simple and intuitive API.`;
-		this.packages = ["igniteui-react-charts@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-charts@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrFinancialChartTemplate();

--- a/templates/react/igr-es6/financial-chart/index.ts
+++ b/templates/react/igr-es6/financial-chart/index.ts
@@ -1,0 +1,15 @@
+import { BaseComponent } from "../../../../lib/BaseComponent";
+
+class IgrFinancialChartComponent extends BaseComponent {
+	/**
+	 *
+	 */
+	constructor() {
+		super(__dirname);
+		this.name  = "Financial Chart";
+		this.group = "Charts";
+		this.description = `charting component that makes it easy to visualize financial data by
+							using a simple and intuitive API.`;
+	}
+}
+module.exports = new IgrFinancialChartComponent();

--- a/templates/react/igr-es6/grid/basic/index.ts
+++ b/templates/react/igr-es6/grid/basic/index.ts
@@ -14,7 +14,7 @@ class GridTemplate extends IgniteUIForReactTemplate {
 		this.projectType = "igr-es6";
 		this.components = ["Grid"];
 		this.controlGroup = "Data Grids";
-		this.packages = ["igniteui-react-grids@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-grids@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 
 		this.hasExtraConfiguration = false;
 	}

--- a/templates/react/igr-es6/linear-gauge/default/index.ts
+++ b/templates/react/igr-es6/linear-gauge/default/index.ts
@@ -10,7 +10,7 @@ class IgrLinearGaugeTemplate extends IgniteUIForReactTemplate {
 		this.projectType = "igr-es6";
 		this.name = "Linear Gauge";
 		this.description = `value compared against a scale and one or more ranges.`;
-		this.packages = ["igniteui-react-gauges@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-gauges@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrLinearGaugeTemplate();

--- a/templates/react/igr-es6/pie-chart/default/index.ts
+++ b/templates/react/igr-es6/pie-chart/default/index.ts
@@ -10,7 +10,7 @@ class IgrPieChartTemplate extends IgniteUIForReactTemplate {
 		this.projectType = "igr-es6";
 		this.name = "Pie Chart";
 		this.description = `easily illustate the proportions of data entries`;
-		this.packages = ["igniteui-react-charts@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-charts@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrPieChartTemplate();

--- a/templates/react/igr-es6/projects/_base/files/package.json
+++ b/templates/react/igr-es6/projects/_base/files/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "igniteui-react-core": "^16.6.4",
+    "igniteui-react-core": "^16.6.5",
     "react": "^16.7.0",
     "react-app-polyfill": "^0.2.0",
     "react-dom": "^16.7.0",

--- a/templates/react/igr-es6/radial-gauge/default/index.ts
+++ b/templates/react/igr-es6/radial-gauge/default/index.ts
@@ -11,7 +11,7 @@ class IgrRadialGaugeTemplate extends IgniteUIForReactTemplate {
 		this.name = "Radial Gauge";
 		this.description = `provides a number of visual elements, like a needle, tick marks, ranges
 							and labels, in order to create a predefined shape and scale.`;
-		this.packages = ["igniteui-react-gauges@^16.6.4"]; // TODO: read version from igniteui-react-core in package.json
+		this.packages = ["igniteui-react-gauges@^16.6.5"]; // TODO: read version from igniteui-react-core in package.json
 	}
 }
 module.exports = new IgrRadialGaugeTemplate();


### PR DESCRIPTION
Closes #445 .  

The financial chart template crashes on destroy, so a new public package of `igniteui-react-charts` has to be published before this is merged
