### PR TITLE
Add projTemplate and theme to GA

### DIFF
--- a/lib/PromptSession.ts
+++ b/lib/PromptSession.ts
@@ -424,6 +424,12 @@ export class PromptSession {
 			case "projectType":
 				text = `  Project type`;
 				break;
+			case "projTemplate":
+				text = `  Proj Template`;
+				break;
+			case "theme":
+				text = `  Theme`;
+				break;
 			default:
 				return;
 				//TODO: text = `  ${options.name}`;

--- a/spec/unit/PromptSession-spec.ts
+++ b/spec/unit/PromptSession-spec.ts
@@ -80,7 +80,8 @@ describe("Unit - PromptSession", () => {
 		spyOn(process, "chdir");
 		spyOn(mockSession, "chooseActionLoop");
 		await mockSession.start();
-		expect(Util.log).toHaveBeenCalledTimes(3);
+		expect(Util.log).toHaveBeenCalledTimes(4);
+		expect(Util.log).toHaveBeenCalledWith("  Proj Template: Project 1");
 		expect(Util.log).toHaveBeenCalledWith("  Generating project structure.");
 		expect(Util.log).toHaveBeenCalledWith("");
 		expect(Util.log).toHaveBeenCalledWith(Util.greenCheck() + " Project structure generated.");
@@ -250,9 +251,10 @@ describe("Unit - PromptSession", () => {
 		spyOn(process, "chdir");
 		spyOn(mockSession, "chooseActionLoop");
 		await mockSession.start();
-		expect(Util.log).toHaveBeenCalledTimes(3);
-		expect(Util.log).toHaveBeenCalledWith("  Generating project structure.");
+		expect(Util.log).toHaveBeenCalledTimes(4);
+		expect(Util.log).toHaveBeenCalledWith("  Proj Template: Project 1");
 		expect(Util.log).toHaveBeenCalledWith("");
+		expect(Util.log).toHaveBeenCalledWith("  Generating project structure.");
 		expect(Util.error).toHaveBeenCalledTimes(1);
 		expect(Util.log).toHaveBeenCalledWith(Util.greenCheck() + " Project structure generated.");
 		expect(Util.isAlphanumericExt).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
When there is single user choice we make the choice without asking the user. In this case we should send the information to GA as if the user has made the choice. Up to now this was done for `framework` and `projectType`. With this PR `projTemplate` and `theme` are added.

Closes #461

