### PR TITLE
Disable animation for gauge tests, drop redundant wait on charts

### DIFF
--- a/templates/angular/igx-ts/bullet-graph/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/bullet-graph/default/files/src/app/__path__/__name__.component.spec.ts
@@ -23,5 +23,7 @@ xdescribe('$(ClassName)Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+    // disable animation
+    component.bulletGraph.transitionDuration = 0;
   });
 });

--- a/templates/angular/igx-ts/bullet-graph/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/bullet-graph/default/files/src/app/__path__/__name__.component.spec.ts
@@ -3,7 +3,7 @@ import { $(ClassName)Component } from './$(filePrefix).component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxBulletGraphModule } from 'igniteui-angular-gauges/ES5/igx-bullet-graph-module';
 
-xdescribe('$(ClassName)Component', () => {
+describe('$(ClassName)Component', () => {
   let component: $(ClassName)Component;
   let fixture: ComponentFixture<$(ClassName)Component>;
 

--- a/templates/angular/igx-ts/category-chart/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/category-chart/default/files/src/app/__path__/__name__.component.spec.ts
@@ -22,8 +22,7 @@ describe('$(ClassName)Component', () => {
     fixture.detectChanges();
   });
 
-  it('should create', done => {
+  it('should create', () => {
     expect(component).toBeTruthy();
-    fixture.whenStable().then(done);
   });
 });

--- a/templates/angular/igx-ts/financial-chart/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/financial-chart/default/files/src/app/__path__/__name__.component.spec.ts
@@ -21,8 +21,7 @@ describe('$(ClassName)Component', () => {
     fixture.detectChanges();
   });
 
-  it('should create', done => {
+  it('should create', () => {
     expect(component).toBeTruthy();
-    fixture.whenStable().then(done);
   });
 });

--- a/templates/angular/igx-ts/linear-gauge/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/linear-gauge/default/files/src/app/__path__/__name__.component.spec.ts
@@ -23,5 +23,7 @@ xdescribe('$(ClassName)Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+    // disable animation
+    component.linearGauge.transitionDuration = 0;
   });
 });

--- a/templates/angular/igx-ts/linear-gauge/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/linear-gauge/default/files/src/app/__path__/__name__.component.spec.ts
@@ -3,7 +3,7 @@ import { $(ClassName)Component } from './$(filePrefix).component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxLinearGaugeModule } from 'igniteui-angular-gauges/ES5/igx-linear-gauge-module';
 
-xdescribe('$(ClassName)Component', () => {
+describe('$(ClassName)Component', () => {
   let component: $(ClassName)Component;
   let fixture: ComponentFixture<$(ClassName)Component>;
 

--- a/templates/angular/igx-ts/radial-gauge/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/radial-gauge/default/files/src/app/__path__/__name__.component.spec.ts
@@ -3,7 +3,7 @@ import { $(ClassName)Component } from './$(filePrefix).component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxRadialGaugeModule } from 'igniteui-angular-gauges/ES5/igx-radial-gauge-module';
 
-xdescribe('$(ClassName)Component', () => {
+describe('$(ClassName)Component', () => {
   let component: $(ClassName)Component;
   let fixture: ComponentFixture<$(ClassName)Component>;
 

--- a/templates/angular/igx-ts/radial-gauge/default/files/src/app/__path__/__name__.component.spec.ts
+++ b/templates/angular/igx-ts/radial-gauge/default/files/src/app/__path__/__name__.component.spec.ts
@@ -23,5 +23,7 @@ xdescribe('$(ClassName)Component', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+    // disable animation
+    component.radialGauge.transitionDuration = 0;
   });
 });


### PR DESCRIPTION
Closes #561

Additional information related to this pull request:

