### PR TITLE
fix(schematics): set virtual FS in proper stage

### DIFF
--- a/packages/igx-templates/IgniteUIForAngularTemplate.ts
+++ b/packages/igx-templates/IgniteUIForAngularTemplate.ts
@@ -121,7 +121,7 @@ export class IgniteUIForAngularTemplate implements Template {
 	}
 	public setExtraConfiguration(extraConfigKeys: {}) { }
 
-	protected getBaseVariables(name: string) {
+	protected getBaseVariables(name: string): { [key: string]: string } {
 		const config = {};
 		config["name"] = Util.nameFromPath(name);
 		config["ClassName"] = Util.className(Util.nameFromPath(name));

--- a/packages/ng-schematics/src/component/index.ts
+++ b/packages/ng-schematics/src/component/index.ts
@@ -43,7 +43,8 @@ function updatePackageJSON(installContext: { packages: Map<string, string>, shou
 }
 
 function addComponent(options: TemplateOptions, skipRoute = false, modulePath?: string): Rule {
-	return async (_tree, _context) => {
+	return async (tree: Tree, _context: SchematicContext) => {
+		setVirtual(tree);
 		const config = options.templateInst.generateConfig(options.name, {});
 		return chain([...options.templateInst.templatePaths.map(templatePath =>
 			mergeWith(
@@ -55,9 +56,8 @@ function addComponent(options: TemplateOptions, skipRoute = false, modulePath?: 
 	};
 }
 export function singleComponent(templateOptions: TemplateOptions, skipRoute: boolean) {
-	return async (tree: Tree, _context: SchematicContext) => {
+	return async (_tree: Tree, _context: SchematicContext) => {
 		const packages = new Map<string, string>();
-		setVirtual(tree);
 		return chain([
 			addComponent(templateOptions, skipRoute),
 			getMissingPackages(templateOptions, packages),


### PR DESCRIPTION
Closes #604.  

The App's fs was never set to virtual when calling the component schematic w/ all options.

This should *not* affect the `ng-new` and `component` w/ prompt options in no way

