### PR TITLE
Check if there is provided user configuration - master

### DIFF
--- a/templates/angular/igx-ts/autocomplete/autocomplete-custom/index.ts
+++ b/templates/angular/igx-ts/autocomplete/autocomplete-custom/index.ts
@@ -6,7 +6,7 @@ class IgxAutocompleteTemplate extends IgniteUIForAngularTemplate {
 		this.components = ["Autocomplete"];
 		this.controlGroup = "Data Entry & Display";
 		this.listInComponentTemplates = true;
-		this.id = "autocomplete";
+		this.id = "extended-autocomplete";
 		this.projectType = "igx-ts";
 		this.name = "Simple Autocomplete";
 		this.description = "Simple IgxAutocomplete";

--- a/templates/angular/igx-ts/autocomplete/autocomplete-custom/index.ts
+++ b/templates/angular/igx-ts/autocomplete/autocomplete-custom/index.ts
@@ -6,7 +6,7 @@ class IgxAutocompleteTemplate extends IgniteUIForAngularTemplate {
 		this.components = ["Autocomplete"];
 		this.controlGroup = "Data Entry & Display";
 		this.listInComponentTemplates = true;
-		this.id = "extended-autocomplete";
+		this.id = "autocomplete";
 		this.projectType = "igx-ts";
 		this.name = "Simple Autocomplete";
 		this.description = "Simple IgxAutocomplete";

--- a/templates/angular/igx-ts/autocomplete/autocomplete-extended/index.ts
+++ b/templates/angular/igx-ts/autocomplete/autocomplete-extended/index.ts
@@ -6,7 +6,7 @@ class IgxAutocompleteTemplate extends IgniteUIForAngularTemplate {
 		this.components = ["Autocomplete"];
 		this.controlGroup = "Data Entry & Display";
 		this.listInComponentTemplates = true;
-		this.id = "autocomplete";
+		this.id = "custom-autocomplete";
 		this.projectType = "igx-ts";
 		this.name = "Enhanced Autocomplete";
 		this.description = "IgxAutocomplete with enhanced groups";

--- a/templates/angular/igx-ts/autocomplete/autocomplete-extended/index.ts
+++ b/templates/angular/igx-ts/autocomplete/autocomplete-extended/index.ts
@@ -6,7 +6,7 @@ class IgxAutocompleteTemplate extends IgniteUIForAngularTemplate {
 		this.components = ["Autocomplete"];
 		this.controlGroup = "Data Entry & Display";
 		this.listInComponentTemplates = true;
-		this.id = "custom-autocomplete";
+		this.id = "enhanced-autocomplete";
 		this.projectType = "igx-ts";
 		this.name = "Enhanced Autocomplete";
 		this.description = "IgxAutocomplete with enhanced groups";

--- a/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
+++ b/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
@@ -1,7 +1,7 @@
 import { IgniteUIForAngularTemplate } from "../../../../../lib/templates/IgniteUIForAngularTemplate";
 
 class IgxHierarchicalGridTemplate extends IgniteUIForAngularTemplate {
-	private userExtraConfiguration: {};
+	private userExtraConfiguration = {};
 	private usePinning: boolean;
 
 	constructor() {
@@ -86,7 +86,7 @@ class IgxHierarchicalGridTemplate extends IgniteUIForAngularTemplate {
 			end: `</a>`
 		};
 
-		if (this.userExtraConfiguration && this.userExtraConfiguration["columnFeatures"]) {
+		if (this.userExtraConfiguration["columnFeatures"]) {
 			const features = this.userExtraConfiguration["columnFeatures"] as string[];
 			const featuresUrls = [];
 			for (const feature of this.userExtraConfiguration["columnFeatures"] as string[]) {

--- a/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
+++ b/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
@@ -86,7 +86,7 @@ class IgxHierarchicalGridTemplate extends IgniteUIForAngularTemplate {
 			end: `</a>`
 		};
 
-		if (this.userExtraConfiguration["columnFeatures"]) {
+		if (this.userExtraConfiguration && this.userExtraConfiguration["columnFeatures"]) {
 			const features = this.userExtraConfiguration["columnFeatures"] as string[];
 			const featuresUrls = [];
 			for (const feature of this.userExtraConfiguration["columnFeatures"] as string[]) {


### PR DESCRIPTION
Closes #606 

While looking at the other templates I found that the two autocomplete templates share the same id. ~I changed them as well so now they are `custom-autocomplete` and `extended-autocomplete`.~
I changed the enhanced autocomplete's id to `enhanced-autocomplete`.