### PR TITLE
fix(add): only take into account 'extraConfig' in template parsing, #618

### DIFF
--- a/lib/templates/AngularTemplate.ts
+++ b/lib/templates/AngularTemplate.ts
@@ -25,17 +25,12 @@ export class AngularTemplate implements Template {
 	constructor(private rootPath: string) {
 	}
 	public generateFiles(projectPath: string, name: string, options: {}): Promise<boolean> {
-		const config = {};
 		if (options["modulePath"] && !Util.fileExists(path.join(process.cwd(), `src\\app`, options["modulePath"]))) {
 			Util.error(`Wrong module path provided: ${options["modulePath"]}. No components were added!`);
 			return Promise.resolve(false);
 		}
 
-		const terms = [];
-		for (const key of Object.keys(options)) {
-			terms.push(options[key]);
-		}
-		Object.assign(config, ...terms, this.getBaseVariables(name));
+		const config = Object.assign({}, options["extraConfig"], this.getBaseVariables(name));
 
 		const pathsConfig = {};
 		if (!Util.validateTemplate(path.join(this.rootPath, "files"), projectPath, config, pathsConfig)) {

--- a/spec/unit/base-templates/AngularTemplate-spec.ts
+++ b/spec/unit/base-templates/AngularTemplate-spec.ts
@@ -46,7 +46,7 @@ describe("Unit - AngularTemplate Base", () => {
 		done();
 	});
 
-	it("generateFiles merge passed variables", async done => {
+	it("generateFiles merges passed variables under extraConfig (only)", async done => {
 		const expected = {
 			"$(name)": "page",
 			"$(ClassName)": "Page",
@@ -66,10 +66,14 @@ describe("Unit - AngularTemplate Base", () => {
 		spyOn(Util, "validateTemplate").and.returnValue(true);
 
 		const templ = new TestWidgetTemplate("root");
-		templ.generateFiles("/target/path", "page", { extraConfig : {
-			"$(extraConfig1)" : "extraConfig1",
-			"$(gridFeatures)" : "{ features }"
-		} });
+		templ.generateFiles("/target/path", "page", { 
+			extraConfig : {
+				"$(extraConfig1)" : "extraConfig1",
+				"$(gridFeatures)" : "{ features }"
+			},
+			modulePath: "some/some.module.ts",
+			skipRoute: false
+		});
 		expect(Util.validateTemplate).toHaveBeenCalledWith(
 			path.join("root" , "files"),
 			"/target/path",

--- a/spec/unit/base-templates/AngularTemplate-spec.ts
+++ b/spec/unit/base-templates/AngularTemplate-spec.ts
@@ -71,8 +71,8 @@ describe("Unit - AngularTemplate Base", () => {
 				"$(extraConfig1)" : "extraConfig1",
 				"$(gridFeatures)" : "{ features }"
 			},
-			modulePath: "some/some.module.ts",
-			skipRoute: false
+			someOtherVar: "some/some.module.ts",
+			someThirdVar: false
 		});
 		expect(Util.validateTemplate).toHaveBeenCalledWith(
 			path.join("root" , "files"),

--- a/spec/unit/base-templates/AngularTemplate-spec.ts
+++ b/spec/unit/base-templates/AngularTemplate-spec.ts
@@ -66,7 +66,7 @@ describe("Unit - AngularTemplate Base", () => {
 		spyOn(Util, "validateTemplate").and.returnValue(true);
 
 		const templ = new TestWidgetTemplate("root");
-		templ.generateFiles("/target/path", "page", { 
+		templ.generateFiles("/target/path", "page", {
 			extraConfig : {
 				"$(extraConfig1)" : "extraConfig1",
 				"$(gridFeatures)" : "{ features }"

--- a/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
+++ b/templates/angular/igx-ts/hierarchical-grid/hierarchical-grid-custom/index.ts
@@ -38,7 +38,6 @@ class IgxHierarchicalGridTemplate extends IgniteUIForAngularTemplate {
 	public generateFiles(projectPath: string, name: string, ...options: any[]): Promise<boolean> {
 		const columnFeatures = [];
 		const gridFeatures = [];
-		let pinningConfig: {};
 		const extraConfig = {
 			"$(selectedFeatures)": this.getSelectedFeatures(columnFeatures, gridFeatures),
 			// tslint:disable-next-line: object-literal-sort-keys
@@ -47,17 +46,17 @@ class IgxHierarchicalGridTemplate extends IgniteUIForAngularTemplate {
 			"$(rowIslandFeatures)": gridFeatures.join(" ").replace(/Singers/g, "Albums")
 		};
 		if (this.usePinning) {
-			pinningConfig = {
+			Object.assign(extraConfig, {
 				"$(album-pin)": this.pinningTemplate("Album"),
 				"$(artist-pin)": this.pinningTemplate("Artist"),
 				"$(awards-pin)": this.pinningTemplate("Awards"),
 				"$(grammy-pin)": this.pinningTemplate("Grammy"),
 				"$(launch-pin)": this.pinningTemplate("Launch"),
 				"$(nominations-pin)": this.pinningTemplate("Nominations")
-			};
+			});
 		}
 
-		return super.generateFiles(projectPath, name, { extraConfig, pinningConfig });
+		return super.generateFiles(projectPath, name, { extraConfig });
 	}
 
 	//tslint:disable


### PR DESCRIPTION
Closes #618   

The `generateFiles` method in the Angular template was executing `Object.assign` with **all** values of the keys of the passed config object. If the **value** was a string, it lead to messy results (as described in the issue).
