### PR TITLE
fix(templates): update angular charts packages to v8.2.12

### DIFF
--- a/packages/igx-templates/igx-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { IgxBulletGraphModule } from 'igniteui-angular-gauges/ES5/igx-bullet-graph-module';
+import { IgxBulletGraphModule } from 'igniteui-angular-gauges';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -1,7 +1,6 @@
 
 import { AfterViewInit, Component, ViewEncapsulation, ViewChild } from '@angular/core';
-import { IgxLinearGraphRangeComponent } from 'igniteui-angular-gauges/ES5/igx-linear-graph-range-component';
-import { IgxBulletGraphComponent } from 'igniteui-angular-gauges/ES5/igx-bullet-graph-component';
+import { IgxLinearGraphRangeComponent, IgxBulletGraphComponent } from 'igniteui-angular-gauges';
 
 @Component({
   selector: 'app-<%=filePrefix%>',

--- a/packages/igx-templates/igx-ts/bullet-graph/default/index.ts
+++ b/packages/igx-templates/igx-ts/bullet-graph/default/index.ts
@@ -12,9 +12,9 @@ class IgxBulletGraphTemplate extends IgniteUIForAngularTemplate {
 		this.description = "IgxBulletGraph with different animations.";
 		this.dependencies = [{
 			import: ["IgxBulletGraphModule"],
-			from: "igniteui-angular-gauges/ES5/igx-bullet-graph-module"
+			from: "igniteui-angular-gauges"
 		}];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-gauges@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-gauges@~8.2.12"];
 	}
 }
 module.exports = new IgxBulletGraphTemplate();

--- a/packages/igx-templates/igx-ts/category-chart/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/category-chart/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
-import { IgxCategoryChartModule } from 'igniteui-angular-charts/ES5/igx-category-chart-module';
+import { IgxCategoryChartModule } from 'igniteui-angular-charts';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/category-chart/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/category-chart/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-<%=filePrefix%>',

--- a/packages/igx-templates/igx-ts/category-chart/default/index.ts
+++ b/packages/igx-templates/igx-ts/category-chart/default/index.ts
@@ -11,10 +11,10 @@ class IgxCategoryChartTemplate extends IgniteUIForAngularTemplate {
 		this.name = "Category Chart";
 		this.description = "basic category chart with chart type selector.";
 		this.dependencies = [
-			{ import: "IgxCategoryChartModule", from: "igniteui-angular-charts/ES5/igx-category-chart-module" },
+			{ import: "IgxCategoryChartModule", from: "igniteui-angular-charts" },
 			{ import: "FormsModule", from: "@angular/forms" }
 		];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-charts@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-charts@~8.2.12"];
 	}
 }
 module.exports = new IgxCategoryChartTemplate();

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 import { IgxGridModule, IgxButtonModule, IgxSwitchModule, IgxSliderModule, IgxCheckboxModule, IgxDialogModule } from 'igniteui-angular';
-import { IgxCategoryChartModule } from 'igniteui-angular-charts/ES5/igx-category-chart-module';
+import { IgxCategoryChartModule } from 'igniteui-angular-charts';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.ts
@@ -6,7 +6,7 @@ import {
     IgxSliderComponent,
     SortingDirection
 } from 'igniteui-angular';
-import { IgxCategoryChartComponent } from 'igniteui-angular-charts/ES5/igx-category-chart-component';
+import { IgxCategoryChartComponent } from 'igniteui-angular-charts';
 import { timer } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import { LocalDataService } from './localData.service';

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/index.ts
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/index.ts
@@ -10,7 +10,7 @@ class IgxFinTechGridTemplate extends IgniteUIForAngularTemplate {
 		this.name = "FinTech Grid";
 		this.description = "Grid with simulated high-frequency data feed";
 		this.dependencies = [
-			{ import: "IgxCategoryChartModule", from: "igniteui-angular-charts/ES5/igx-category-chart-module" },
+			{ import: "IgxCategoryChartModule", from: "igniteui-angular-charts" },
 			{ provide: "IgxExcelExporterService", from: "igniteui-angular" },
 			{
 				import: [
@@ -28,7 +28,7 @@ class IgxFinTechGridTemplate extends IgniteUIForAngularTemplate {
 			},
 			{ import: "FormsModule", from: "@angular/forms" }
 		];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-charts@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-charts@~8.2.12"];
 	}
 }
 module.exports = new IgxFinTechGridTemplate();

--- a/packages/igx-templates/igx-ts/financial-chart/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/financial-chart/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
-import { IgxFinancialChartModule } from 'igniteui-angular-charts/ES5/igx-financial-chart-module';
+import { IgxFinancialChartModule } from 'igniteui-angular-charts';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/financial-chart/default/index.ts
+++ b/packages/igx-templates/igx-ts/financial-chart/default/index.ts
@@ -11,9 +11,9 @@ class IgxFinancialChartTemplate extends IgniteUIForAngularTemplate {
 		this.name = "Financial Chart";
 		this.description = "basic financial chart with automatic toolbar and type selection.";
 		this.dependencies = [
-			{ import: "IgxFinancialChartModule", from: "igniteui-angular-charts/ES5/igx-financial-chart-module" }
+			{ import: "IgxFinancialChartModule", from: "igniteui-angular-charts" }
 		];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-charts@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-charts@~8.2.12"];
 	}
 }
 module.exports = new IgxFinancialChartTemplate();

--- a/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { IgxLinearGaugeModule } from 'igniteui-angular-gauges/ES5/igx-linear-gauge-module';
+import { IgxLinearGaugeModule } from 'igniteui-angular-gauges';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -1,7 +1,8 @@
 import { Component, AfterViewInit, ViewEncapsulation, ViewChild } from '@angular/core';
-import { IgxLinearGaugeComponent } from 'igniteui-angular-gauges/ES5/igx-linear-gauge-component';
-import { IgxLinearGraphRangeComponent } from 'igniteui-angular-gauges/ES5/igx-linear-graph-range-component';
-import { LinearGraphNeedleShape } from 'igniteui-angular-gauges/ES5/LinearGraphNeedleShape';
+import { 
+	IgxLinearGaugeComponent, IgxLinearGraphRangeComponent,
+	LinearGraphNeedleShape
+} from 'igniteui-angular-gauges';
 
 @Component({
   selector: 'app-<%=filePrefix%>',

--- a/packages/igx-templates/igx-ts/linear-gauge/default/index.ts
+++ b/packages/igx-templates/igx-ts/linear-gauge/default/index.ts
@@ -13,10 +13,10 @@ class IgxLinearGaugeTemplate extends IgniteUIForAngularTemplate {
 		this.dependencies = [
 			{
 				import: ["IgxLinearGaugeModule"],
-				from: "igniteui-angular-gauges/ES5/igx-linear-gauge-module"
+				from: "igniteui-angular-gauges"
 			}
 		];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-gauges@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-gauges@~8.2.12"];
 	}
 }
 module.exports = new IgxLinearGaugeTemplate();

--- a/packages/igx-templates/igx-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { IgxRadialGaugeModule } from 'igniteui-angular-gauges/ES5/igx-radial-gauge-module';
+import { IgxRadialGaugeModule } from 'igniteui-angular-gauges';
 
 describe('<%=ClassName%>Component', () => {
   let component: <%=ClassName%>Component;

--- a/packages/igx-templates/igx-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -1,12 +1,10 @@
 import { Component, AfterViewInit, ViewEncapsulation, ViewChild } from '@angular/core';
 // radial gauge imports
-import { SweepDirection } from 'igniteui-angular-core/ES5/SweepDirection';
-import { IgxRadialGaugeComponent } from 'igniteui-angular-gauges/ES5/igx-radial-gauge-component';
-import { IgxRadialGaugeRangeComponent } from 'igniteui-angular-gauges/ES5/igx-radial-gauge-range-component';
-import { RadialGaugeBackingShape } from 'igniteui-angular-gauges/ES5/RadialGaugeBackingShape';
-import { RadialGaugeNeedleShape } from 'igniteui-angular-gauges/ES5/RadialGaugeNeedleShape';
-import { RadialGaugePivotShape } from 'igniteui-angular-gauges/ES5/RadialGaugePivotShape';
-import { RadialGaugeScaleOversweepShape } from 'igniteui-angular-gauges/ES5/RadialGaugeScaleOversweepShape';
+import { SweepDirection } from 'igniteui-angular-core';
+import { 
+	IgxRadialGaugeComponent, IgxRadialGaugeRangeComponent, RadialGaugeBackingShape,
+	RadialGaugeNeedleShape, RadialGaugePivotShape, RadialGaugeScaleOversweepShape
+} from 'igniteui-angular-gauges';
 
 @Component({
   selector: 'app-<%=filePrefix%>',

--- a/packages/igx-templates/igx-ts/radial-gauge/default/index.ts
+++ b/packages/igx-templates/igx-ts/radial-gauge/default/index.ts
@@ -13,10 +13,10 @@ class IgxRadialGaugeTemplate extends IgniteUIForAngularTemplate {
 		this.dependencies = [
 			{
 				import: ["IgxRadialGaugeModule"],
-				from: "igniteui-angular-gauges/ES5/igx-radial-gauge-module"
+				from: "igniteui-angular-gauges"
 			}
 		];
-		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.0.0", "igniteui-angular-gauges@~8.0.0"];
+		this.packages = ["tslib@^1.7.1", "igniteui-angular-core@~8.2.12", "igniteui-angular-gauges@~8.2.12"];
 	}
 }
 module.exports = new IgxRadialGaugeTemplate();


### PR DESCRIPTION
Closes #624.

Charts are now using the updated `8.2.12` packages.
Imports are done from the main feature module instead of submodules:

**Previous**
`import { IgxBulletGraphComponent } from 'igniteui-angular-gauges/ES5/igx-bullet-graph-component';`
**Current**
`import { IgxBulletGraphComponent } from 'igniteui-angular-gauges';`


