### PR TITLE
fix(react): update react projects to use node-sass ^4.9.0

### DIFF
--- a/templates/quickstart/react/package.json
+++ b/templates/quickstart/react/package.json
@@ -15,15 +15,15 @@
   "bin": {
   },
   "dependencies": {
-    "ignite-ui": "~18.1",
+    "ignite-ui": "~19.2",
     "lite-server": "^2.3.0",
     "babel-runtime": "6.22.0",
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "react-router": "2.8.0",
     "igniteui-react": "^1.2.0",
-    "jquery": "3.2.1",
-    "jquery-ui": "1.12.1"
+    "jquery": "^3.2.1",
+    "jquery-ui": "^1.12.1"
   },
   "devDependencies": {
     "babel-core": "6.16.0",
@@ -35,8 +35,6 @@
     "extract-text-webpack-plugin": "2.0.0-beta.5",
     "file-loader": "0.8.5",
     "html-webpack-plugin": "2.26.0",
-    "node-sass": "3.12.2",
-    "sass-loader": "3.2.3",
     "style-loader": "0.13.1",
     "webpack": "2.2.0",
     "webpack-dev-server": "2.2.0"

--- a/templates/react/es6/projects/empty/files/package.json
+++ b/templates/react/es6/projects/empty/files/package.json
@@ -32,7 +32,7 @@
     "html-webpack-plugin": "2.26.0",
     "igniteui-cli": "^$(cliVersion)",
     "jest": "^22.4.2",
-    "node-sass": "4.5.3",
+    "node-sass": "^4.9.0",
     "react-test-renderer": "^15.6.2",
     "sass-loader": "3.2.3",
     "style-loader": "0.13.1",


### PR DESCRIPTION
Closes #635 .  

The `quickstart` project doesn't really use sass, but it's nice to have consistency.
