### PR TITLE
Removing unnecessary . in a link in a CLI warning message.

### DIFF
--- a/packages/cli/lib/PromptSession.ts
+++ b/packages/cli/lib/PromptSession.ts
@@ -68,7 +68,7 @@ export class PromptSession extends BasePromptSession {
 			projLibrary = await this.getProjectLibrary(framework);
 			if (frameRes === "Angular" && projLibrary.projectType === "igx-ts") {
 				Util.log("Psst! Did you know you can also use our schematics package to modify your Angular project directly, using the ng cli?", "yellow");
-				Util.log("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html.", "yellow");
+				Util.log("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html", "yellow");
 			}
 			const projTemplate = await this.getProjectTemplate(projLibrary);
 			// project options:

--- a/packages/cli/lib/commands/add.ts
+++ b/packages/cli/lib/commands/add.ts
@@ -84,7 +84,7 @@ command = {
 
 		if (framework.id === "angular" && frameworkLibrary.projectType === "igx-ts") {
 			Util.warn("Psst! Did you know you can also use our schematics package to modify your Angular project directly, using the ng cli?", "yellow");
-			Util.warn("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html.", "yellow");
+			Util.warn("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html", "yellow");
 		}
 
 		const selectedTemplate = frameworkLibrary.getTemplateById(argv.template);

--- a/packages/cli/lib/commands/new.ts
+++ b/packages/cli/lib/commands/new.ts
@@ -97,7 +97,7 @@ command = {
 
 		if (command.template.getFrameworkById(argv.framework).id === "angular" && projectLib.projectType === "igx-ts") {
 			Util.warn("Psst! Did you know you can also use our schematics package to modify your Angular project directly, using the ng cli?", "yellow");
-			Util.warn("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html.", "yellow");
+			Util.warn("Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html", "yellow");
 		}
 
 		let themeIndex = 0;


### PR DESCRIPTION
Removed the . from
"Read more at: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/getting_started.html." which was resulting in a faulty link:

![cli warning link](https://user-images.githubusercontent.com/9549439/73830065-ad265780-480c-11ea-9484-303ab7f059c2.png)

