### PR TITLE
fix(carousel template, igx) images not displayed #682

### DIFF
--- a/packages/igx-templates/igx-ts/carousel/default/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/carousel/default/files/src/app/__path__/__filePrefix__.component.scss
@@ -5,7 +5,15 @@
   align-items: center;
 }
 .carousel-container {
-  width: 80%;
+	width: 80%;
+	min-height:50%;
+  
+	img {
+		width: auto;
+		margin: 0 auto;
+		display: flex;
+	}
+  
 }
 @media only screen and (max-width: 768px) {
   .carousel-container {


### PR DESCRIPTION
Closes #682 

The carousel's images were not displayed due to missing min-width of the parent container.
