### PR TITLE
Failing test - Add noop animations module 

### DIFF
--- a/packages/igx-templates/igx-ts/carousel/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/carousel/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 import { IgxCarouselModule } from 'igniteui-angular';
@@ -10,7 +11,7 @@ describe('<%=ClassName%>Component', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [<%=ClassName%>Component],
-      imports: [IgxCarouselModule]
+      imports: [NoopAnimationsModule, IgxCarouselModule]
     })
       .compileComponents();
   }));


### PR DESCRIPTION
There is a failing test when executing _ig test_. It requires animations module.