### PR TITLE
fix(templates): upgrade command properly replaces strings in ALL .ts files

### DIFF
--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -14,7 +14,7 @@ export class FsFileSystem implements IFileSystem {
 	}
 	public readFile(filePath: string, encoding?: string): string {
 		if (encoding) {
-		return fs.readFileSync(filePath, encoding);
+			return fs.readFileSync(filePath, encoding);
 		}
 		return fs.readFileSync(filePath).toString();
 	}

--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -6,11 +6,15 @@ import { IFileSystem } from "../types/FileSystem";
 
 export class FsFileSystem implements IFileSystem {
 	public fileExists(filePath: string): boolean {
-		return fs.existsSync(filePath);
+		try {
+			return fs.statSync(filePath).isFile();
+		} catch (err) {
+			return false;
+		}
 	}
 	public readFile(filePath: string, encoding?: string): string {
 		if (encoding) {
-			return fs.readFileSync(filePath, encoding);
+		return fs.readFileSync(filePath, encoding);
 		}
 		return fs.readFileSync(filePath).toString();
 	}
@@ -18,7 +22,11 @@ export class FsFileSystem implements IFileSystem {
 		fs.writeFileSync(filePath, text);
 	}
 	public directoryExists(dirPath: string): boolean {
-		return fs.statSync(dirPath).isDirectory();
+		try {
+			return fs.statSync(dirPath).isDirectory();
+		} catch (e) {
+			return false;
+		}
 	}
 
 	public glob(dirPath: string, pattern: string): string[] {

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -36,19 +36,11 @@ export class Util {
 	}
 
 	public static directoryExists(dirPath) {
-		try {
-			return App.container.get<IFileSystem>(FS_TOKEN).directoryExists(dirPath);
-		} catch (err) {
-			return false;
-		}
+		return App.container.get<IFileSystem>(FS_TOKEN).directoryExists(dirPath);
 	}
 
 	public static fileExists(filePath) {
-		try {
-			return App.container.get<IFileSystem>(FS_TOKEN).fileExists(filePath);
-		} catch (err) {
-			return false;
-		}
+		return App.container.get<IFileSystem>(FS_TOKEN).fileExists(filePath);
 	}
 
 	public static isDirectory(dirPath): boolean {

--- a/packages/igx-templates/Update.spec.ts
+++ b/packages/igx-templates/Update.spec.ts
@@ -145,8 +145,26 @@ export class HomeComponent {
 			]
 		}
 	}
+}`}, {
+	path: "src/app.module.ts",
+	content:
+`import { something } from 'module';
+import { bait } from 'igniteui-angular-core';
+import { IgxGridComponent } from 'igniteui-angular';
+
+export class HomeComponent {
+title = 'igniteui-angular example';
+}`,
+	expected:
+`import { something } from 'module';
+import { bait } from 'igniteui-angular-core';
+import { IgxGridComponent } from '@infragistics/igniteui-angular';
+
+export class HomeComponent {
+title = 'igniteui-angular example';
 }`}];
-		(fsSpy.glob as jasmine.Spy).and.returnValue(["src/home.component.ts", "src/home.component.scss"]);
+		(fsSpy.glob as jasmine.Spy).and.returnValue(
+			["src/home.component.ts", "src/home.component.scss", "src/app.module.ts"]);
 		(fsSpy.readFile as jasmine.Spy).and.callFake((filePath: string) => {
 			if (filePath.indexOf("package.json") > -1) {
 				return JSON.stringify(mockPackageJSON);

--- a/packages/igx-templates/Update.ts
+++ b/packages/igx-templates/Update.ts
@@ -52,7 +52,7 @@ export async function updateWorkspace(): Promise<boolean> {
 	const logicFiles = [];
 	const styleFiles = [];
 	for (const workspace of workspaces) {
-		logicFiles.push(...fs.glob(workspace, "**/*.component.ts"));
+		logicFiles.push(...fs.glob(workspace, "**/*.ts"));
 		for (const extension of styleExtension) {
 			styleFiles.push(...fs.glob(workspace, `**/*.${extension}`));
 		}

--- a/spec/unit/ProjectConfig-spec.ts
+++ b/spec/unit/ProjectConfig-spec.ts
@@ -4,19 +4,18 @@ import * as os from "os";
 
 describe("Unit - ProjectConfig", () => {
 	it("hasLocalConfig returns correct values", async done => {
-
 		const cwdSpy = spyOn(process, "cwd");
 		spyOn(os, "homedir").and.returnValues("rootDir");
-		spyOn(fs, "existsSync").and.returnValue(true);
+		spyOn(fs, "statSync").and.returnValue({ isFile: () => true });
 
 		// cwd matches homedir
 		cwdSpy.and.returnValue("rootDir");
 		expect(ProjectConfig.hasLocalConfig()).toBeFalsy();
-		expect(fs.existsSync).toHaveBeenCalledTimes(0);
+		expect(fs.statSync).toHaveBeenCalledTimes(0);
 
 		cwdSpy.and.returnValue("rootDir/somePath");
 		expect(ProjectConfig.hasLocalConfig()).toBeTruthy();
-		expect(fs.existsSync).toHaveBeenCalledTimes(1);
+		expect(fs.statSync).toHaveBeenCalledTimes(1);
 
 		done();
 	});

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -1,4 +1,4 @@
-import { FsFileSystem, GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
+import { GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
 import * as fs from "fs";
 import * as ts from "typescript";
 
@@ -435,12 +435,12 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				super.readFormatConfigs();
 			}
 		}
-		const existsSpy = spyOn(fs, "existsSync");
+		const existsSpy = spyOn(fs, "statSync");
 		existsSpy.and.callFake(filePath => {
 			if (filePath !== "tslint.json") {
 				// "spec/unit/ts-transform/unformatted.ts-template":
 				// ".editorconfig":
-					return true;
+				return { isFile: () => true };
 			}
 			return false;
 		});
@@ -474,7 +474,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		expect(tsUpdate.getFormatting().singleQuotes).toEqual(false);
 
 		// with tslint
-		existsSpy.and.returnValue(true);
+		existsSpy.and.returnValue({ isFile: () => true });
 		testTslint = {
 			rules: {
 				"prefer-const": true,


### PR DESCRIPTION
Related to #723 .  

Command was not properly capturing all .ts files, only `*.component.ts`.

`FsFileSystem` implementation of `fileExists` and `directoryExists` was not correct and could throw.