### PR TITLE
fix(igx,templates): correct empty proj template id

### DIFF
--- a/packages/igx-templates/igx-ts/projects/empty/index.ts
+++ b/packages/igx-templates/igx-ts/projects/empty/index.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { BaseIgxProject } from "../_base";
 
 export class EmptyPageTemplate extends BaseIgxProject implements ProjectTemplate {
-	public id: string = "empty-project";
+	public id: string = "empty";
 	public name = "Empty Project";
 	public description = "Project structure with routing and a home page";
 	public dependencies: string[] = [];


### PR DESCRIPTION
Related to changes for #617 .  

Additional information related to this pull request:
Project was getting generated with `"projectTemplate": "empty-project",` in the config, which may provide wrong info to other logic relying on it.
