### PR TITLE
fix(upgrade): sort packages.json dependencies when adding licensed package

### DIFF
--- a/packages/igx-templates/Update.spec.ts
+++ b/packages/igx-templates/Update.spec.ts
@@ -55,6 +55,8 @@ describe("updateWorkspace - Unit tests", () => {
 	it("Should update package.json file, removing non-scoped igniteui-angular packages", async () => {
 		const mockPackageJSON = {
 			dependencies: {
+				"@alphabetically-sorted-scope/package": "^0.0.0",
+				"alphabetically-second-package": "^0.0.0",
 				"igniteui-angular": "^9.1.0",
 				"some-package": "^0.0.0"
 			}
@@ -75,8 +77,10 @@ describe("updateWorkspace - Unit tests", () => {
 		expect(await updateWorkspace()).toEqual(false);
 		expect(fsSpy.writeFile).toHaveBeenCalledWith("package.json", JSON.stringify({
 			dependencies: {
-				"some-package": "^0.0.0",
-				"@infragistics/igniteui-angular": "^9.1.0"
+				"@alphabetically-sorted-scope/package": "^0.0.0",
+				"@infragistics/igniteui-angular": "^9.1.0",
+				"alphabetically-second-package": "^0.0.0",
+				"some-package": "^0.0.0"
 			}
 		}, null, 2));
 	});

--- a/packages/igx-templates/Update.ts
+++ b/packages/igx-templates/Update.ts
@@ -23,10 +23,14 @@ export async function updateWorkspace(): Promise<boolean> {
 	if (fileString) {
 		const pkgJSON = JSON.parse(fileString);
 		const errorMsg = "Something went wrong, " +
-		"please follow the steps in this guide: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/ignite-ui-licensing.html";
+			"please follow the steps in this guide: https://www.infragistics.com/products/ignite-ui-angular/angular/components/general/ignite-ui-licensing.html";
 		if (PackageManager.ensureRegistryUser(config, errorMsg)) {
 			pkgJSON.dependencies[FEED_PACKAGE] = pkgJSON.dependencies[NPM_PACKAGE];
 			delete pkgJSON.dependencies[NPM_PACKAGE];
+			pkgJSON.dependencies =
+				Object.keys(pkgJSON.dependencies)
+					.sort()
+					.reduce((result, key) => (result[key] = pkgJSON.dependencies[key]) && result, {});
 			fs.writeFile("package.json", JSON.stringify(pkgJSON, null, 2));
 		} else {
 			return false;


### PR DESCRIPTION
When updating package.json dependencies w/ `@infragistics` scoped packages, ensure that the dependencies object has properly sorted keys.