### PR TITLE
fix(upgrade): provide default fallback for incorrect package template

### DIFF
--- a/packages/cli/lib/commands/upgrade.ts
+++ b/packages/cli/lib/commands/upgrade.ts
@@ -46,7 +46,7 @@ command = {
 				if (projectType === "igx-ts") {
 					const projectLibrary = command.templateManager.getProjectLibrary(framework, projectType);
 					let project;
-					if (!config.project.projectTemplate) {
+					if (!config.project.projectTemplate || !projectLibrary.hasProject(config.project.projectTemplate)) {
 						// in case project template is missing from the config we provide backward.
 						project = projectLibrary.getProject(projectLibrary.projectIds[0]);
 					} else {

--- a/packages/ng-schematics/src/upgrade-packages/index.spec.ts
+++ b/packages/ng-schematics/src/upgrade-packages/index.spec.ts
@@ -36,7 +36,9 @@ describe("Schematics upgrade-packages", () => {
 		};
 		const upgradeSpy = spyOn(mockProjTemplate, "upgradeIgniteUIPackages");
 		const mockLib: Partial<ProjectLibrary> = {
-			getProject: jasmine.createSpy().and.returnValue(mockProjTemplate)
+			getProject: jasmine.createSpy().and.returnValue(mockProjTemplate),
+			hasProject: jasmine.createSpy().and.returnValue(false),
+			projectIds: ["another-mock"]
 		};
 		const projLibSpy = spyOn(SchematicsTemplateManager.prototype, "getProjectLibrary");
 		projLibSpy.and.returnValue(mockLib);
@@ -48,7 +50,8 @@ describe("Schematics upgrade-packages", () => {
 			cd: "Upgrade packages"
 		});
 		expect(projLibSpy).toHaveBeenCalledWith("mock-ng", "mock-igx-ts");
-		expect(mockLib.getProject).toHaveBeenCalledWith("mock-side-nav");
+		expect(mockLib.hasProject).toHaveBeenCalledWith("mock-side-nav");
+		expect(mockLib.getProject).toHaveBeenCalledWith("another-mock");
 		expect(App.container.get(FS_TYPE_TOKEN)).toEqual(FsTypes.virtual, "setVirtual not called");
 		expect(App.container.get(FS_TOKEN)).toEqual(jasmine.any(NgTreeFileSystem));
 

--- a/packages/ng-schematics/src/upgrade-packages/index.ts
+++ b/packages/ng-schematics/src/upgrade-packages/index.ts
@@ -1,6 +1,6 @@
 import { Rule, SchematicContext, Tree } from "@angular-devkit/schematics";
 import { NodePackageInstallTask } from "@angular-devkit/schematics/tasks";
-import { App, GoogleAnalytics, ProjectConfig } from "@igniteui/cli-core";
+import { App, GoogleAnalytics, ProjectConfig, ProjectTemplate } from "@igniteui/cli-core";
 import { defer } from "rxjs";
 import { SchematicsTemplateManager } from "../SchematicsTemplateManager";
 import { setVirtual } from "../utils/NgFileSystem";
@@ -19,7 +19,13 @@ export default function(options: UpgradeOptions): Rule {
 		const templateManager = new SchematicsTemplateManager();
 		const config = ProjectConfig.getConfig();
 		const library = templateManager.getProjectLibrary(config.project.framework, config.project.projectType);
-		const project = library.getProject(config.project.projectTemplate);
+		let project: ProjectTemplate;
+		if (!config.project.projectTemplate || !library.hasProject(config.project.projectTemplate)) {
+			// in case project template is missing from the config we provide backward.
+			project = library.getProject(library.projectIds[0]);
+		} else {
+			project = library.getProject(config.project.projectTemplate);
+		}
 		setVirtual(tree);
 		return defer(async () => {
 			const success = await project.upgradeIgniteUIPackages("", "");

--- a/spec/unit/upgrade-spec.ts
+++ b/spec/unit/upgrade-spec.ts
@@ -30,7 +30,7 @@ describe("Unit - Upgrade command", () => {
 		const mockProject: Partial<ProjectTemplate> = {
 			upgradeIgniteUIPackages: () => null
 		};
-		const mockProjLib: Partial<ProjectLibrary> = { getProject: () => null };
+		const mockProjLib: Partial<ProjectLibrary> = { getProject: () => null, hasProject: () => true };
 		const mockTemplateManager: Partial<BaseTemplateManager> = { getProjectLibrary: () => null };
 		upgradeCmd.templateManager = mockTemplateManager as any;
 		spyOn(mockTemplateManager, "getProjectLibrary").and.returnValue(mockProjLib);


### PR DESCRIPTION
Related #723 and #727 
If the package template is not a recognized one (e.g. `ng-cli`), we provide the default template for that library (e.g. the first one)

