### PR TITLE
chore(schematics): add migratoins collection, update group

### DIFF
--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -27,7 +27,11 @@
     "typescript": "~3.7.5"
   },
   "ng-update": {
+    "migrations": "./src/migrations/migration-collection.json",
     "packageGroup": [
+      "igniteui-angular",
+      "@infragistics/igniteui-angular",
+      "igniteui-angular-charts",
       "@igniteui/angular-templates"
     ]
   }

--- a/packages/ng-schematics/src/migrations/migration-collection.json
+++ b/packages/ng-schematics/src/migrations/migration-collection.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+  }
+}


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:
Despite having an `ng-update` in the package.json, `ng update` doesn't offer newer version of the package for update. Adding an empty collection as well, hopefully that'll trigger it to offer the update.
