### PR TITLE
fix(package-manager): manually update pckgJSON when adding packages

### DIFF
--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -176,6 +176,16 @@ export class Util {
 		}
 	}
 
+	public static formatPackageJson(json: { dependencies: { [key: string]: string } }, sort = true): string {
+		if (sort) {
+			json.dependencies =
+			Object.keys(json.dependencies)
+				.sort()
+				.reduce((result, key) => (result[key] = json.dependencies[key]) && result, {});
+		}
+		return JSON.stringify(json, null, 2) + "\n";
+	}
+
 	public static version(filePath?: string): string {
 		const configuration = require(filePath || "../package.json");
 		return configuration.version;

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -1,4 +1,4 @@
-import { Config, PackageManager, ProjectConfig, Util } from "@igniteui/cli-core";
+import { App, Config, IFileSystem, PackageManager, ProjectConfig, Util } from "@igniteui/cli-core";
 import * as cp from "child_process";
 import * as path from "path";
 import { resetSpy } from "../helpers/utils";
@@ -31,11 +31,12 @@ describe("Unit - Package Manager", () => {
 		spyOn(ProjectConfig, "setConfig");
 		spyOn(PackageManager, "addPackage").and.returnValue(true);
 		spyOn(path, "join").and.returnValue("fakemodule.json");
-		spyOn(require("module"), "_load").and.callFake((modulePath: string) => {
-			if (modulePath === "fakemodule.json") {
-				return mockRequire;
-			}
-		});
+		const mockFs: Partial<IFileSystem> = {
+			readFile: jasmine.createSpy().and.returnValue(JSON.stringify(mockRequire)),
+			writeFile: jasmine.createSpy()
+		};
+		// should ignore already installed
+		spyOn(App.container, "get").and.returnValue(mockFs);
 		spyOn(Util, "execSync").and.callFake((cmd: string, opts) => {
 			if (cmd.includes("whoami")) {
 				throw new Error("");
@@ -365,7 +366,7 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledTimes(0);
 		expect(cp.exec).toHaveBeenCalledTimes(1);
 		expect(cp.exec).toHaveBeenCalledWith(
-			`npm install test-pack --quiet --save`, {}, jasmine.any(Function));
+			`npm install test-pack --quiet --no-save`, {}, jasmine.any(Function));
 		done();
 	});
 
@@ -375,8 +376,12 @@ describe("Unit - Package Manager", () => {
 				"test-pack": "19.2"
 			}
 		};
+		const mockFs: Partial<IFileSystem> = {
+			readFile: jasmine.createSpy().and.returnValue(JSON.stringify(mockRequire)),
+			writeFile: jasmine.createSpy()
+		};
 		// should ignore already installed
-		spyOn(require("module"), "_load").and.returnValue(mockRequire);
+		spyOn(App.container, "get").and.returnValue(mockFs);
 		spyOn(Util, "log");
 		const execSpy = spyOn(cp, "exec");
 		PackageManager.queuePackage("test-pack");
@@ -396,8 +401,13 @@ describe("Unit - Package Manager", () => {
 			dependencies: {}
 		};
 		// should ignore already installed
-		spyOn(require("module"), "_load").and.returnValue(mockRequire);
+		const mockFs: Partial<IFileSystem> = {
+			readFile: jasmine.createSpy().and.returnValue(JSON.stringify(mockRequire)),
+			writeFile: jasmine.createSpy()
+		};
+		// spyOn(require("module"), "_load").and.returnValue(mockRequire);
 		spyOn(Util, "log");
+		spyOn(App.container, "get").and.returnValue(mockFs);
 		const execSpy = spyOn(cp, "exec").and.callFake((cmd, opts, callback) => {
 			setTimeout(() => callback(null, [1], [2]), 20);
 		});


### PR DESCRIPTION
Co-authored-by: Damyan Petev <damyan.petev@gmail.com>

Closes #751.  

Additional information related to this pull request:

`npm install` fails to update package.json when there are other changes. When calling `queuePackage`, manually update package.json

