### PR TITLE
Change igx nav proj padding and adjust dock manager/fintech views

### DIFF
--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.html
@@ -37,7 +37,7 @@
 
     <igx-grid #grid1
         (onRowSelectionChange)="rowSelectionChanged($event)" [data]="data"
-        [height]="'calc(100% - 71px)'" width="100%" [autoGenerate]='false' displayDensity='compact'
+        [height]="'calc(100% - 81px)'" width="100%" [autoGenerate]='false' displayDensity='compact'
         columnHidingTitle="Indicators" hiddenColumnsText="Hidden" primaryKey='ID' [rowSelection]="'multiple'"
         [allowFiltering]="true" [filterMode]="'excelStyleFilter'" [showToolbar]="false" [columnHiding]="true"
         [columnPinning]="true" [exportExcel]="true" exportExcelText="Export to Excel">

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.scss
@@ -1,6 +1,7 @@
 :host {
     display: block;
     width: 100%;
+    padding: 0 !important;
 }
 :host ::ng-deep {
     .fintech-icons {
@@ -204,7 +205,7 @@
 
 .grid__wrapper {
     padding: 5px 15px;
-    height: 95%;
+    height: 100%;
 }
 
 @import '~<%=igxPackage%>/lib/core/styles/themes/utilities';

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.scss
@@ -196,7 +196,7 @@
 
 .grid__wrapper {
     padding: 5px 15px;
-    height: 95%;
+    height: 100%;
 }
 
 // Custom Dark Theme	
@@ -212,6 +212,9 @@
 $green-palette: igx-palette($primary: #09f,$secondary: #72da67, $surface: #333);	
 
 :host {
+    padding: 0 !important;
+    width: 100%;
+
     ::ng-deep {
 
         @include scrollbar-love();

--- a/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.scss
@@ -4,4 +4,5 @@
 
 :host {
   flex: 1 1 auto;
+  padding: 0 !important;
 }

--- a/packages/igx-templates/igx-ts/projects/_base/files/src/styles.scss
+++ b/packages/igx-templates/igx-ts/projects/_base/files/src/styles.scss
@@ -7,6 +7,3 @@
 html, body {
   height: 100%;
 }
-.content p {
-  margin: 15px;
-}

--- a/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.html
+++ b/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div igxLayout>
+<div class="outer-wrapper" igxLayout>
   <igx-nav-drawer #nav id="project-menu" isOpen="true" [enableGestures]='true' width="280px">
     <ng-template igxDrawer>
       <span igxDrawerItem [isHeader]="true">Views</span>

--- a/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.scss
+++ b/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.scss
@@ -1,5 +1,4 @@
-
-:host > div {
+.outer-wrapper {
   height: 100%;
 }
 
@@ -9,13 +8,23 @@
   flex-flow: row nowrap;
   justify-content: center;
   align-items: stretch;
-  padding: 0 24px;
   overflow: auto;
+
+  > *:not(router-outlet) {
+    padding: 0 24px;
+  }
+
+  p {
+    margin: 15px;
+  }
 }
 
 @media only screen and (max-width: 1024px) {
   .content {
-    padding: 0 15px;
     justify-content: flex-start;
+
+    > *:not(router-outlet) {
+      padding: 0 15px;
+    }
   }
 }

--- a/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.ts
+++ b/packages/igx-templates/igx-ts/projects/side-nav/files/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
@@ -10,7 +10,8 @@ import { IgxNavigationDrawerComponent } from 'igniteui-angular';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
+  encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements OnInit {
   public topNavLinks: Array<{


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:
Updated the padding for side-nav projects (no change for empty) so some views can override it and fill up the entire content. Especially for the dock manager, but also tried to tidy up the FinTech Grids a bit as well (dark enabled to show the diff):
![image](https://user-images.githubusercontent.com/3198469/84371111-d8b5b600-abe1-11ea-9312-9a93a5738980.png)

