### PR TITLE
fix(igx,dock-manager): resolve package name from project

### DIFF
--- a/packages/igx-templates/IgniteUIForAngularTemplate.ts
+++ b/packages/igx-templates/IgniteUIForAngularTemplate.ts
@@ -3,7 +3,7 @@ import {
 	ControlExtraConfiguration, FS_TOKEN, IFileSystem, Template, TemplateDependency, TypeScriptFileUpdate, Util
 } from "@igniteui/cli-core";
 import * as path from "path";
-import { resolveIgxPackage } from "./package-resolve";
+import { NPM_DOCK_MANAGER, NPM_PACKAGE, resolveIgxPackage } from "./package-resolve";
 
 export class IgniteUIForAngularTemplate implements Template {
 	public components: string[];
@@ -116,7 +116,8 @@ export class IgniteUIForAngularTemplate implements Template {
 		config["description"] = this.description;
 		config["cliVersion"] = Util.version();
 		config["camelCaseName"] = Util.camelCase(name);
-		config["igxPackage"] = resolveIgxPackage();
+		config["igxPackage"] = resolveIgxPackage(NPM_PACKAGE);
+		config["dockManagerPackage"] = resolveIgxPackage(NPM_DOCK_MANAGER);
 
 		/** 'nameMerged' is never used igx templates, removed */
 		return config;

--- a/packages/igx-templates/Update.spec.ts
+++ b/packages/igx-templates/Update.spec.ts
@@ -9,7 +9,7 @@ interface MockFile {
 }
 
 // tslint:disable: object-literal-sort-keys
-describe("updateWorkspace - Unit tests", () => {
+describe("Igx templates - updateWorkspace", () => {
 	let fsSpy: IFileSystem;
 	beforeAll(() => {
 		fsSpy = jasmine.createSpyObj("fsSpy", ["fileExists", "directoryExists", "readFile", "writeFile", "glob"]);
@@ -25,7 +25,11 @@ describe("updateWorkspace - Unit tests", () => {
 	});
 
 	it("Should fail if no packages.json is found", async () => {
-		spyOn(pkgResolve, "getUpgradeablePackages").and.returnValue([pkgResolve.UPGRADEABLE_PACKAGES[0]]);
+		const upgradable: pkgResolve.PackageDefinition = {
+			trial: pkgResolve.NPM_PACKAGE,
+			licensed: pkgResolve.FEED_PACKAGE
+		};
+		spyOn(pkgResolve, "getUpgradeablePackages").and.returnValue([upgradable]);
 		(fsSpy.directoryExists as jasmine.Spy).and.returnValue(false);
 		(fsSpy.readFile as jasmine.Spy).and.returnValue("");
 		spyOn(Util, "log");
@@ -37,7 +41,11 @@ describe("updateWorkspace - Unit tests", () => {
 		const mockJSONInput = {
 			someName: "testValue"
 		};
-		spyOn(pkgResolve, "getUpgradeablePackages").and.returnValue([pkgResolve.UPGRADEABLE_PACKAGES[0]]);
+		const upgradable: pkgResolve.PackageDefinition = {
+			trial: pkgResolve.NPM_PACKAGE,
+			licensed: pkgResolve.FEED_PACKAGE
+		};
+		spyOn(pkgResolve, "getUpgradeablePackages").and.returnValue([upgradable]);
 		(fsSpy.directoryExists as jasmine.Spy).and.returnValue(false);
 		(fsSpy.readFile as jasmine.Spy).and.returnValue(JSON.stringify(mockJSONInput, null, 4));
 		spyOn(PackageManager, "ensureRegistryUser").and.returnValue(false);

--- a/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.spec.ts
+++ b/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 
-import { defineCustomElements } from 'igniteui-dockmanager/loader';
+import { defineCustomElements } from '<%=dockManagerPackage%>/loader';
 defineCustomElements();
 
 describe('<%=ClassName%>Component', () => {

--- a/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { IgcDockManagerLayout,
   IgcDockManagerPaneType,
   IgcSplitPaneOrientation
-} from 'igniteui-dockmanager';
+} from '<%=dockManagerPackage%>';
 
 @Component({
   selector: 'app-<%=filePrefix%>',

--- a/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.module.ts
+++ b/packages/igx-templates/igx-ts/dock-manager/default/files/src/app/__path__/__filePrefix__.module.ts
@@ -2,7 +2,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { <%=ClassName%>Component } from './<%=filePrefix%>.component';
 
-import { defineCustomElements } from 'igniteui-dockmanager/loader';
+import { defineCustomElements } from '<%=dockManagerPackage%>/loader';
 defineCustomElements();
 
 @NgModule({

--- a/packages/igx-templates/igx-ts/dock-manager/default/index.ts
+++ b/packages/igx-templates/igx-ts/dock-manager/default/index.ts
@@ -1,5 +1,6 @@
 import { TypeScriptFileUpdate } from "@igniteui/cli-core";
 import { IgniteUIForAngularTemplate } from "../../../IgniteUIForAngularTemplate";
+import { NPM_DOCK_MANAGER, resolveIgxPackage } from "../../../package-resolve";
 
 class IgcDockManagerTemplate extends IgniteUIForAngularTemplate {
 	constructor() {
@@ -14,7 +15,8 @@ class IgcDockManagerTemplate extends IgniteUIForAngularTemplate {
 		this.dependencies = [
 			{ import: "DockManagerModule", from: "./src/app/<%=path%>/<%=filePrefix%>.module.ts" }
 		];
-		this.packages = ["igniteui-dockmanager@~1.0.0"];
+		// "igniteui-dockmanager@~1.0.0":
+		this.packages = [ `${resolveIgxPackage(NPM_DOCK_MANAGER)}@~1.0.0"` ];
 	}
 	protected addClassDeclaration(mainModule: TypeScriptFileUpdate, projPath: string, name: string, modulePath: string) {
 		// not applicable with custom module

--- a/packages/ng-schematics/src/cli-config/index.ts
+++ b/packages/ng-schematics/src/cli-config/index.ts
@@ -1,7 +1,7 @@
 import { DependencyNotFoundException } from "@angular-devkit/core";
 import { yellow } from "@angular-devkit/core/src/terminal";
 import { chain, FileDoesNotExistException, Rule, Tree } from "@angular-devkit/schematics";
-import { resolveIgxPackage } from "@igniteui/angular-templates";
+import { NPM_PACKAGE, resolveIgxPackage } from "@igniteui/angular-templates";
 import { addTypography, TypeScriptFileUpdate } from "@igniteui/cli-core";
 import { createCliConfig } from "../utils/cli-config";
 import { setVirtual } from "../utils/NgFileSystem";
@@ -33,7 +33,7 @@ function getDependencyVersion(pkg: string, tree: Tree): string {
 
 function displayVersionMismatch(): Rule {
 	return (tree: Tree) => {
-		const igxPackage = resolveIgxPackage();
+		const igxPackage = resolveIgxPackage(NPM_PACKAGE);
 		const pkgJson = JSON.parse(tree.read(`/node_modules/${igxPackage}/package.json`)!.toString());
 		const ngKey = "@angular/core";
 		const ngCommonKey = "@angular/common";

--- a/packages/ng-schematics/src/utils/theme-import.ts
+++ b/packages/ng-schematics/src/utils/theme-import.ts
@@ -1,6 +1,6 @@
 import { SchematicsException } from "@angular-devkit/schematics";
 import { Tree } from "@angular-devkit/schematics/src/tree/interface";
-import { resolveIgxPackage } from "@igniteui/angular-templates";
+import { NPM_PACKAGE, resolveIgxPackage } from "@igniteui/angular-templates";
 import { getWorkspace } from "@schematics/angular/utility/config";
 import { ProjectType, WorkspaceProject, WorkspaceSchema } from "@schematics/angular/utility/workspace-models";
 import * as path from "path";
@@ -39,7 +39,7 @@ export function addFontsToIndexHtml(tree: Tree) {
 }
 
 function importDefaultThemeSass(tree: Tree, ext: string): Tree {
-	const igxPackage = resolveIgxPackage();
+	const igxPackage = resolveIgxPackage(NPM_PACKAGE);
 	const sassImports =
 	`
 @import "~${igxPackage}/lib/core/styles/themes/index";
@@ -104,7 +104,7 @@ export function getDefaultProjectBuildOptions(tree: Tree) {
 }
 
 function importDefaultThemeToAngularWorkspace(workspace: WorkspaceSchema, key: string) {
-	const igxPackage = resolveIgxPackage();
+	const igxPackage = resolveIgxPackage(NPM_PACKAGE);
 	const cssImport = `node_modules/${igxPackage}/styles/igniteui-angular.css`;
 	const projectName = workspace.defaultProject;
 	if (projectName) {

--- a/spec/unit/base-templates/IgniteUIForAngularTemplate-spec.ts
+++ b/spec/unit/base-templates/IgniteUIForAngularTemplate-spec.ts
@@ -1,4 +1,4 @@
-import { FEED_PACKAGE, IgniteUIForAngularTemplate, NPM_PACKAGE } from "@igniteui/angular-templates";
+import { FEED_PACKAGE, IgniteUIForAngularTemplate, NPM_DOCK_MANAGER, NPM_PACKAGE } from "@igniteui/angular-templates";
 import { App, FS_TOKEN, IFileSystem, ProjectConfig, TypeScriptFileUpdate, Util } from "@igniteui/cli-core";
 import * as path from "path";
 import { resetSpy } from "../../helpers/utils";
@@ -135,14 +135,17 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 				ClassName: "Test",
 				cliVersion: Util.version(),
 				description: "test description",
+				dockManagerPackage: `${NPM_DOCK_MANAGER}`,
+				igxPackage: `${NPM_PACKAGE}`
+			};
+			Object.assign(expected, {
 				// extra
 				extraConfig1 : "extraConfig1",
 				filePrefix: "test",
 				gridFeatures : "{ features }",
-				igxPackage: `${NPM_PACKAGE}`,
 				name: "test",
 				path: "test"
-			};
+			});
 
 			const options = {
 				extraConfig : {


### PR DESCRIPTION
This allows dock manager template to be added after project packages
upgrade with correct package name without need for additional upgrade.

Closes # .  

Additional information related to this pull request:

