### PR TITLE
feat(tsutil): add optional parent route to TsFileUpdateUtil.addRoute method

### DIFF
--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -6,7 +6,6 @@ import { Util } from "../util/Util";
 import { TypeScriptUtils as TsUtils } from "./TypeScriptUtils";
 
 const DEFAULT_ROUTES_VARIABLE = "routes";
-declare type NodeVisitor = (node: ts.Node) => ts.Node;
 /**
  * Apply various updates to typescript files using AST
  */
@@ -65,130 +64,25 @@ export class TypeScriptFileUpdate {
 	 * @param filePath Path to the component file to import
 	 * @param linkPath Routing `path` to add
 	 * @param linkText Text of the route to add as `data.text`
+	 * @param parentRoutePath Will include the new route as a **child** of the specified route path
 	 * @param routesVariable Name of the array variable holding routes
-	 * @param parentRoutePath __Optional__ If passed, will include the new route as a **child** of the specified route path
 	 */
-	public addRoute(
-		filePath: string,
-		linkPath: string,
-		linkText: string,
-		routesVariable = DEFAULT_ROUTES_VARIABLE,
-		parentRoutePath?: string
-	) {
-		let className: string;
-		const fileSource = TsUtils.getFileSource(filePath);
-		const relativePath: string = Util.relativePath(this.targetPath, filePath, true, true);
-		routesVariable = routesVariable || DEFAULT_ROUTES_VARIABLE;
-		className = TsUtils.getClassName(fileSource.getChildren());
-		this.requestImport([className], relativePath);
+	public addChildRoute(
+		filePath: string, linkPath: string, linkText: string, parentRoutePath: string,
+		routesVariable = DEFAULT_ROUTES_VARIABLE) {
+		this.addRouteModuleEntry(filePath, linkPath, linkText, routesVariable, parentRoutePath);
+	}
 
-		// https://github.com/Microsoft/TypeScript/issues/14419#issuecomment-307256171
-		const transformer: ts.TransformerFactory<ts.Node> = <T extends ts.Node>(context: ts.TransformationContext) =>
-			(rootNode: T) => {
-				let conditionalVisitor: NodeVisitor;
-				if (parentRoutePath === undefined) {
-					conditionalVisitor = (node: ts.Node): ts.Node => {
-						if (node.kind === ts.SyntaxKind.ArrayLiteralExpression) {
-							const newObject = this.createRouteEntry(linkPath, className, linkText);
-							const array = (node as ts.ArrayLiteralExpression);
-							this.createdStringLiterals.push(linkPath, linkText);
-							const notFoundWildCard = "**";
-							const nodes = ts.visitNodes(array.elements, visitor);
-							const errorRouteNode = nodes.filter(element => element.getText().includes(notFoundWildCard))[0];
-							let resultNodes = null;
-							if (errorRouteNode) {
-								resultNodes = nodes
-									.slice(0, nodes.indexOf(errorRouteNode))
-									.concat(newObject)
-									.concat(errorRouteNode);
-							} else {
-								resultNodes = nodes
-									.concat(newObject);
-							}
-
-							const elements = ts.createNodeArray([
-								...resultNodes
-							]);
-
-							return ts.updateArrayLiteral(array, elements);
-						} else {
-							return ts.visitEachChild(node, conditionalVisitor, context);
-						}
-					};
-				} else {
-					conditionalVisitor = (node: ts.Node): ts.Node => {
-						if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-							if (!node.getText().includes(parentRoutePath)) {
-								return node;
-							}
-							function filterForChildren(element: ts.Node): boolean {
-								if (element.kind === ts.SyntaxKind.PropertyAssignment) {
-									const identifier = element.getChildren()[0];
-									return identifier.kind === ts.SyntaxKind.Identifier && identifier.getText().trim() === "children";
-								}
-								return false;
-							}
-							const newObject = this.createRouteEntry(linkPath, className, linkText);
-							const currentNode = node as ts.ObjectLiteralExpression;
-							this.createdStringLiterals.push(linkPath, linkText);
-							const syntaxList: ts.SyntaxList = node.getChildren()
-								.filter(element => element.kind === ts.SyntaxKind.SyntaxList)[0] as ts.SyntaxList;
-							let childrenProperty: ts.PropertyAssignment = syntaxList
-								.getChildren().filter(filterForChildren)[0] as ts.PropertyAssignment;
-							let childrenArray: ts.ArrayLiteralExpression = null;
-
-							// if the target parent route already has child routes - get them
-							// if not - create an empty 'chuldren' array
-							if (childrenProperty) {
-								childrenArray = childrenProperty.getChildren()
-									.filter(element => element.kind === ts.SyntaxKind.ArrayLiteralExpression)[0] as ts.ArrayLiteralExpression
-									|| ts.createArrayLiteral();
-							} else {
-								childrenArray = ts.createArrayLiteral();
-							}
-
-							let existingProperties = syntaxList.getChildren()
-								.filter(element => element.kind !== ts.SyntaxKind["CommaToken"]) as ts.ObjectLiteralElementLike[];
-							const newArrayValues = childrenArray.elements.concat(newObject);
-							if (!childrenProperty) {
-								const propertyName = "children";
-								const propertyValue = ts.createArrayLiteral([...newArrayValues]);
-								childrenProperty = ts.createPropertyAssignment(propertyName, propertyValue);
-								existingProperties = existingProperties
-									.concat(childrenProperty);
-							} else {
-								const index = existingProperties.indexOf(childrenProperty);
-								const childrenPropertyName = childrenProperty.name;
-								childrenProperty =
-									ts.updatePropertyAssignment(
-										childrenProperty,
-										childrenPropertyName,
-										ts.createArrayLiteral([...newArrayValues])
-									);
-								existingProperties
-									.splice(index, 1, childrenProperty);
-							}
-							return ts.updateObjectLiteral(currentNode, existingProperties) as ts.Node;
-						} else {
-							return ts.visitEachChild(node, conditionalVisitor, context);
-						}
-					};
-				}
-				const visitCondition = (node: ts.Node): boolean => {
-					return node.kind === ts.SyntaxKind.VariableDeclaration &&
-						(node as ts.VariableDeclaration).name.getText() === routesVariable &&
-						(node as ts.VariableDeclaration).type.getText() === "Routes";
-				};
-				const visitor: NodeVisitor = this.createVisitor(conditionalVisitor, visitCondition, context);
-				context.enableSubstitution(ts.SyntaxKind.ClassDeclaration);
-				return ts.visitNode(rootNode, visitor);
-			};
-
-		this.targetSource = ts.transform(this.targetSource, [transformer], {
-			pretty: true // oh well..
-		}).transformed[0] as ts.SourceFile;
-
-		this.finalize();
+	/**
+	 * Create configuration object for a component and add it to the `Routes` array variable.
+	 * Imports the first exported class and finalizes the file update (see `.finalize()`).
+	 * @param filePath Path to the component file to import
+	 * @param linkPath Routing `path` to add
+	 * @param linkText Text of the route to add as `data.text`
+	 * @param routesVariable Name of the array variable holding routes
+	 */
+	public addRoute(filePath: string, linkPath: string, linkText: string, routesVariable = DEFAULT_ROUTES_VARIABLE) {
+		this.addRouteModuleEntry(filePath, linkPath, linkText, routesVariable);
 	}
 
 	/**
@@ -290,6 +184,143 @@ export class TypeScriptFileUpdate {
 
 	//#endregion File state
 
+	protected addRouteModuleEntry(
+		filePath: string,
+		linkPath: string,
+		linkText: string,
+		routesVariable = DEFAULT_ROUTES_VARIABLE,
+		parentRoutePath?: string
+	) {
+		let className: string;
+		const fileSource = TsUtils.getFileSource(filePath);
+		const relativePath: string = Util.relativePath(this.targetPath, filePath, true, true);
+		className = TsUtils.getClassName(fileSource.getChildren());
+		this.requestImport([className], relativePath);
+
+		// https://github.com/Microsoft/TypeScript/issues/14419#issuecomment-307256171
+		const transformer: ts.TransformerFactory<ts.Node> = <T extends ts.Node>(context: ts.TransformationContext) =>
+			(rootNode: T) => {
+				let conditionalVisitor: ts.Visitor;
+				// the visitor that should be used when adding routes to the main route array
+				const routeArrayVisitor = (node: ts.Node): ts.Node => {
+					if (node.kind === ts.SyntaxKind.ArrayLiteralExpression) {
+						const newObject = this.createRouteEntry(linkPath, className, linkText);
+						const array = (node as ts.ArrayLiteralExpression);
+						this.createdStringLiterals.push(linkPath, linkText);
+						const notFoundWildCard = "**";
+						const nodes = ts.visitNodes(array.elements, visitor);
+						const errorRouteNode = nodes.filter(element => element.getText().includes(notFoundWildCard))[0];
+						let resultNodes = null;
+						if (errorRouteNode) {
+							resultNodes = nodes
+								.slice(0, nodes.indexOf(errorRouteNode))
+								.concat(newObject)
+								.concat(errorRouteNode);
+						} else {
+							resultNodes = nodes
+								.concat(newObject);
+						}
+
+						const elements = ts.createNodeArray([
+							...resultNodes
+						]);
+
+						return ts.updateArrayLiteral(array, elements);
+					} else {
+						return ts.visitEachChild(node, conditionalVisitor, context);
+					}
+				};
+				// the visitor that should be used when adding child routes to a specified parent
+				const parentRouteVisitor = (node: ts.Node): ts.Node => {
+					if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+						if (!node.getText().includes(parentRoutePath)) {
+							return node;
+						}
+						const nodeProperties = (node as ts.ObjectLiteralExpression).properties;
+						const parentPropertyCheck = (element: ts.PropertyAssignment) => {
+							return element.name.kind === ts.SyntaxKind.Identifier && element.name.text === "path"
+								&& element.initializer.kind === ts.SyntaxKind.StringLiteral
+								&& (element.initializer as ts.StringLiteral).text === parentRoutePath;
+						};
+						const parentProperty = nodeProperties.filter(parentPropertyCheck)[0];
+						if (!parentProperty) {
+							return node;
+						}
+						function filterForChildren(element: ts.Node): boolean {
+							if (element.kind === ts.SyntaxKind.PropertyAssignment) {
+								const identifier = element.getChildren()[0];
+								return identifier.kind === ts.SyntaxKind.Identifier && identifier.getText().trim() === "children";
+							}
+							return false;
+						}
+						const newObject = this.createRouteEntry(linkPath, className, linkText);
+						const currentNode = node as ts.ObjectLiteralExpression;
+						this.createdStringLiterals.push(linkPath, linkText);
+						const syntaxList: ts.SyntaxList = node.getChildren()
+							.filter(element => element.kind === ts.SyntaxKind.SyntaxList)[0] as ts.SyntaxList;
+						let childrenProperty: ts.PropertyAssignment = syntaxList
+							.getChildren().filter(filterForChildren)[0] as ts.PropertyAssignment;
+						let childrenArray: ts.ArrayLiteralExpression = null;
+
+						// if the target parent route already has child routes - get them
+						// if not - create an empty 'chuldren' array
+						if (childrenProperty) {
+							childrenArray = childrenProperty.getChildren()
+								.filter(element => element.kind === ts.SyntaxKind.ArrayLiteralExpression)[0] as ts.ArrayLiteralExpression
+								|| ts.createArrayLiteral();
+						} else {
+							childrenArray = ts.createArrayLiteral();
+						}
+
+						let existingProperties = syntaxList.getChildren()
+							.filter(element => element.kind !== ts.SyntaxKind["CommaToken"]) as ts.ObjectLiteralElementLike[];
+						const newArrayValues = childrenArray.elements.concat(newObject);
+						if (!childrenProperty) {
+							const propertyName = "children";
+							const propertyValue = ts.createArrayLiteral([...newArrayValues]);
+							childrenProperty = ts.createPropertyAssignment(propertyName, propertyValue);
+							existingProperties = existingProperties
+								.concat(childrenProperty);
+						} else {
+							const index = existingProperties.indexOf(childrenProperty);
+							const childrenPropertyName = childrenProperty.name;
+							childrenProperty =
+								ts.updatePropertyAssignment(
+									childrenProperty,
+									childrenPropertyName,
+									ts.createArrayLiteral([...newArrayValues])
+								);
+							existingProperties
+								.splice(index, 1, childrenProperty);
+						}
+						return ts.updateObjectLiteral(currentNode, existingProperties) as ts.Node;
+					} else {
+						return ts.visitEachChild(node, conditionalVisitor, context);
+					}
+				};
+
+				if (parentRoutePath === undefined) {
+					conditionalVisitor = routeArrayVisitor;
+				} else {
+					conditionalVisitor = parentRouteVisitor;
+				}
+				const visitCondition = (node: ts.Node): boolean => {
+					return node.kind === ts.SyntaxKind.VariableDeclaration &&
+						(node as ts.VariableDeclaration).name.getText() === routesVariable &&
+						(node as ts.VariableDeclaration).type.getText() === "Routes";
+				};
+				const visitor: ts.Visitor = this.createVisitor(conditionalVisitor, visitCondition, context);
+				context.enableSubstitution(ts.SyntaxKind.ClassDeclaration);
+				return ts.visitNode(rootNode, visitor);
+			};
+
+		this.targetSource = ts.transform(this.targetSource, [transformer], {
+			pretty: true // oh well..
+		}).transformed[0] as ts.SourceFile;
+
+		this.finalize();
+	}
+
 	/**
 	 * Add named imports from a path/package.
 	 * @param identifiers Strings to create named import from ("Module" => `import { Module }`)
@@ -371,7 +402,7 @@ export class TypeScriptFileUpdate {
 	/** Transformation to apply `this.ngMetaEdits` to `NgModule` metadata properties */
 	protected ngModuleTransformer: ts.TransformerFactory<ts.Node> =
 		<T extends ts.Node>(context: ts.TransformationContext) => (rootNode: T) => {
-			const visitNgModule: NodeVisitor = (node: ts.Node): ts.Node => {
+			const visitNgModule: ts.Visitor = (node: ts.Node): ts.Node => {
 				const properties: string[] = []; // "declarations", "imports", "providers"
 				for (const key in this.ngMetaEdits) {
 					if (this.ngMetaEdits[key].length) {
@@ -601,10 +632,10 @@ export class TypeScriptFileUpdate {
 	}
 
 	private createVisitor(
-		conditionalVisitor: NodeVisitor,
+		conditionalVisitor: ts.Visitor,
 		visitCondition: (node: ts.Node) => boolean,
 		nodeContext: ts.TransformationContext
-	): NodeVisitor {
+	): ts.Visitor {
 		return function visitor(node: ts.Node): ts.Node {
 			if (visitCondition(node)) {
 				node = ts.visitEachChild(node, conditionalVisitor, nodeContext);

--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -121,7 +121,7 @@ export class TypeScriptFileUpdate {
 						}
 						// Get all property assignements from SyntaxList
 						let existingProperties = syntaxList.getChildren()
-							.filter(element => element.kind === ts.SyntaxKind.PropertyAssignment) as ts.ObjectLiteralElementLike[];
+							.filter(element => element.kind !== ts.SyntaxKind["CommaToken"]) as ts.ObjectLiteralElementLike[];
 						const newArrayValues = childrenArray.elements.concat(newObject);
 						if (!childrenProperty) {
 							const propertyName = "children";

--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -32,7 +32,6 @@ export class TypeScriptFileUpdate {
 
 	/** Create updates for a file. Use `add<X>` methods to add transformations and `finalize` to apply and save them. */
 	constructor(private targetPath: string) {
-		this.targetSource = TsUtils.getFileSource(this.targetPath);
 		this.fileSystem = App.container.get<IFileSystem>(FS_TOKEN);
 		this.initState();
 	}
@@ -238,6 +237,7 @@ export class TypeScriptFileUpdate {
 
 	/** Initializes existing imports info, [re]sets import and `NgModule` edits */
 	protected initState() {
+		this.targetSource = TsUtils.getFileSource(this.targetPath);
 		this.importsMeta = this.loadImportsMeta();
 		this.requestedImports = [];
 		this.ngMetaEdits = {

--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -59,6 +59,114 @@ export class TypeScriptFileUpdate {
 	}
 
 	/**
+	 * Add a child route under the passed parent element inside of the specified routing module
+	 * @param filePath the path to the routing file
+	 * @param linkPath route path
+	 * @param parentRouteName the path of the component
+	 * @param routesVariable
+	 */
+	public addChildRoute(filePath: string, linkPath: string, parentRouteName: string, routesVariable = "routes") {
+		let className: string;
+		const fileSource = TsUtils.getFileSource(filePath);
+		const relativePath: string = Util.relativePath(this.targetPath, filePath, true, true);
+
+		className = TsUtils.getClassName(fileSource.getChildren());
+		this.requestImport([className], relativePath);
+
+		// https://github.com/Microsoft/TypeScript/issues/14419#issuecomment-307256171
+		const transformer: ts.TransformerFactory<ts.Node> = <T extends ts.Node>(context: ts.TransformationContext) =>
+			(rootNode: T) => {
+				function visitor(node: ts.Node): ts.Node {
+					if (node.kind === ts.SyntaxKind.VariableDeclaration &&
+						(node as ts.VariableDeclaration).name.getText() === routesVariable &&
+						(node as ts.VariableDeclaration).type.getText() === "Routes") {
+						// found routes variable
+						node = ts.visitEachChild(node, visitRoutesVariable, context);
+					} else {
+						node = ts.visitEachChild(node, visitor, context);
+					}
+					return node;
+				}
+				function filterForChildren(node: ts.Node): boolean {
+					if (node.kind === ts.SyntaxKind.PropertyAssignment) {
+						const identifier = node.getChildren()[0];
+						return identifier.kind === ts.SyntaxKind.Identifier && identifier.getText().trim() === "children";
+					}
+					return false;
+				}
+				const visitRoutesVariable = (node: ts.Node): ts.Node => {
+					if (node.kind === ts.SyntaxKind.ArrayLiteralExpression) {
+						const array = (node as ts.ArrayLiteralExpression);
+						const routePath = ts.createPropertyAssignment("path", ts.createLiteral(linkPath));
+						const routeComponent = ts.createPropertyAssignment("component", ts.createIdentifier(className));
+						const newObject = ts.createObjectLiteral([routePath, routeComponent]);
+						this.createdStringLiterals.push(linkPath);
+						const nodes = ts.visitNodes(array.elements, visitor);
+						const targetParentNode: ts.ObjectLiteralExpression = nodes
+							.filter(element => element.getText().includes(parentRouteName))[0] as ts.ObjectLiteralExpression;
+						if (!targetParentNode) {
+							return node;
+						}
+						const syntaxList: ts.SyntaxList = targetParentNode.getChildren()
+							.filter(element => element.kind === ts.SyntaxKind.SyntaxList)[0] as ts.SyntaxList;
+						let childrenProperty: ts.PropertyAssignment = syntaxList
+							.getChildren().filter(filterForChildren)[0] as ts.PropertyAssignment;
+						let childrenArray: ts.ArrayLiteralExpression = null;
+						if (childrenProperty) {
+							childrenArray = childrenProperty.getChildren()
+								.filter(element => element.kind === ts.SyntaxKind.ArrayLiteralExpression)[0] as ts.ArrayLiteralExpression
+								|| ts.createArrayLiteral();
+						} else {
+							childrenArray = ts.createArrayLiteral();
+						}
+						// Get all property assignements from SyntaxList
+						let existingProperties = syntaxList.getChildren()
+							.filter(element => element.kind === ts.SyntaxKind.PropertyAssignment) as ts.ObjectLiteralElementLike[];
+						const newArrayValues = childrenArray.elements.concat(newObject);
+						if (!childrenProperty) {
+							const propertyName = "children";
+							const propertyValue = ts.createArrayLiteral([...newArrayValues]);
+							childrenProperty = ts.createPropertyAssignment(propertyName, propertyValue);
+							existingProperties = existingProperties
+								.concat(childrenProperty);
+						} else {
+							const index = existingProperties.indexOf(childrenProperty);
+							const childrenPropertyName = childrenProperty.name;
+							childrenProperty =
+								ts.updatePropertyAssignment(childrenProperty, childrenPropertyName, ts.createArrayLiteral([...newArrayValues]));
+							//  ts.updatePropertyAssignment(childrenProperty, "children", newArray)
+							existingProperties
+								.splice(index, 1, childrenProperty);
+						}
+
+						// Create new object literal by creating one w/ all existing property assignments + children
+						const newTargetNode = ts.createObjectLiteral(existingProperties);
+						// Replace targetParentNode w/ newly created objectLiteral in routes
+						const resultNodes = [...nodes];
+
+						resultNodes.splice(resultNodes.indexOf(targetParentNode), 1, newTargetNode);
+
+						const elements = ts.createNodeArray([
+							...resultNodes
+						]);
+
+						return ts.updateArrayLiteral(array, elements);
+					} else {
+						return ts.visitEachChild(node, visitRoutesVariable, context);
+					}
+				};
+				context.enableSubstitution(ts.SyntaxKind.ClassDeclaration);
+				return ts.visitNode(rootNode, visitor);
+			};
+
+		this.targetSource = ts.transform(this.targetSource, [transformer], {
+			pretty: true // oh well..
+		}).transformed[0] as ts.SourceFile;
+
+		this.finalize();
+	}
+
+	/**
 	 * Create configuration object for a component and add it to the `Routes` array variable.
 	 * Imports the first exported class and finalizes the file update (see `.finalize()`).
 	 * @param filePath Path to the component file to import

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -214,7 +214,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		done();
 	});
 
-	fit("Adds child routes", async done => {
+	it("Adds child routes", async done => {
 		let sourceCalls = 0;
 		spyOn(TypeScriptUtils, "getFileSource").and.callFake((input: string) => {
 			if (input === "route-module.ts") {

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -146,8 +146,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		});
 	});
 
-	fit("Adds routes", async done => {
-		App.initialize();
+	it("Adds routes", async done => {
 		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
 			ts.createSourceFile("route-module.ts", `
 				const routes: Routes = [
@@ -198,10 +197,11 @@ describe("Unit - TypeScriptFileUpdate", () => {
 	});
 
 	fit("Adds child routes", async done => {
+		App.initialize();
 		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
 			ts.createSourceFile("route-module.ts", `
 				const routes: Routes = [
-					{ path: 'parent', component: ParentComponent }
+					{ path: 'parent', exising }
 				];
 			`, ts.ScriptTarget.Latest, true),
 			{ getChildren: () => ["component1"] },
@@ -222,7 +222,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			"route-module.ts",
 			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
 				`const routes: Routes = \\[\\s*` +
-				`{ path: 'parent', component: ParentComponent, children:\\s*` +
+				`{ path: 'parent', exising, children:\\s*` +
 				`\\[\\{ path: "child-1", component: Component1 }\\]\\ }\\s*` +
 				`\\];\\s*`
 			)
@@ -238,7 +238,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
 				`import { Component2 } from "./to/component2";\\s*` +
 				`const routes: Routes = \\[\\s*` +
-				`{ path: 'parent', component: ParentComponent, children:\\s*` +
+				`{ path: 'parent', exising, children:\\s*` +
 				`\\[\\{ path: "child-1", component: Component1 }, { path: "child-2", component: Component2 }\\]\\ }\\s*` +
 				`\\];\\s*`
 			)

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -140,7 +140,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			tsUpdate.addNgModuleMeta({ provide: "testProvide", from: "package" });
 			expect(requestImportSpy).toHaveBeenCalledWith(["testProvide"], "package");
 			//combine
-			tsUpdate.addNgModuleMeta({ import: "import1", declare: ["declare1", "declare2"], provide: "prov1", from: "package" });
+			tsUpdate.addNgModuleMeta({import: "import1", declare: ["declare1", "declare2"], provide: "prov1", from: "package"});
 			expect(requestImportSpy).toHaveBeenCalledWith(["import1", "declare1", "declare2", "prov1"], "package");
 			done();
 		});
@@ -196,7 +196,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		done();
 	});
 
-	fit("Adds child routes", async done => {
+	it("Adds child routes", async done => {
 		App.initialize();
 		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
 			ts.createSourceFile("route-module.ts", `
@@ -215,7 +215,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		const tsUpdate = new TypeScriptFileUpdate("route-module.ts");
 
 		// call when parent route has no child routes
-		tsUpdate.addChildRoute("path/to/component", "child-1", "parent");
+		tsUpdate.addRoute("path/to/component", "child-1", "child one", "", "parent");
 		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component", true, true);
 		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component1"]);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -223,14 +223,14 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
 				`const routes: Routes = \\[\\s*` +
 				`{ path: 'parent', exising, children:\\s*` +
-				`\\[\\{ path: "child-1", component: Component1 }\\]\\ }\\s*` +
+				`\\[\\{ path: "child-1", component: Component1, data: { text: "child one" } }\\]\\ }\\s*` +
 				`\\];\\s*`
 			)
 		);
 		expect(formatSpy).toHaveBeenCalled();
 
 		// call when parent route has child routes
-		tsUpdate.addChildRoute("path/to/component2", "child-2", "parent");
+		tsUpdate.addRoute("path/to/component2", "child-2", "child two", "", "parent");
 		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component2", true, true);
 		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component2"]);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -239,7 +239,8 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				`import { Component2 } from "./to/component2";\\s*` +
 				`const routes: Routes = \\[\\s*` +
 				`{ path: 'parent', exising, children:\\s*` +
-				`\\[\\{ path: "child-1", component: Component1 }, { path: "child-2", component: Component2 }\\]\\ }\\s*` +
+				`\\[\\{ path: "child-1", component: Component1, data: { text: "child one" } },\\s*` +
+				`{ path: "child-2", component: Component2, data: { text: "child two" } }\\]\\ }\\s*` +
 				`\\];\\s*`
 			)
 		);

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -1,4 +1,4 @@
-import { GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
+import { App, GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
 import * as fs from "fs";
 import * as ts from "typescript";
 
@@ -131,22 +131,23 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			const requestImportSpy = spyOn(TestTsFileUpdate.prototype, "requestImport").and.callThrough();
 
 			const tsUpdate = new TestTsFileUpdate("/test/file");
-			tsUpdate.addNgModuleMeta({import: "test"});
+			tsUpdate.addNgModuleMeta({ import: "test" });
 			expect(requestImportSpy).toHaveBeenCalledTimes(0);
-			tsUpdate.addNgModuleMeta({import: "testImport", from: "package"});
+			tsUpdate.addNgModuleMeta({ import: "testImport", from: "package" });
 			expect(requestImportSpy).toHaveBeenCalledWith(["testImport"], "package");
-			tsUpdate.addNgModuleMeta({declare: "testDeclare", from: "package"});
+			tsUpdate.addNgModuleMeta({ declare: "testDeclare", from: "package" });
 			expect(requestImportSpy).toHaveBeenCalledWith(["testDeclare"], "package");
-			tsUpdate.addNgModuleMeta({provide: "testProvide", from: "package"});
+			tsUpdate.addNgModuleMeta({ provide: "testProvide", from: "package" });
 			expect(requestImportSpy).toHaveBeenCalledWith(["testProvide"], "package");
 			//combine
-			tsUpdate.addNgModuleMeta({import: "import1", declare: ["declare1", "declare2"], provide: "prov1", from: "package"});
+			tsUpdate.addNgModuleMeta({ import: "import1", declare: ["declare1", "declare2"], provide: "prov1", from: "package" });
 			expect(requestImportSpy).toHaveBeenCalledWith(["import1", "declare1", "declare2", "prov1"], "package");
 			done();
 		});
 	});
 
-	it("Adds routes", async done => {
+	fit("Adds routes", async done => {
+		App.initialize();
 		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
 			ts.createSourceFile("route-module.ts", `
 				const routes: Routes = [
@@ -184,12 +185,62 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		expect(fs.writeFileSync).toHaveBeenCalledWith(
 			"route-module.ts",
 			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
-			`import { Component2 } from "./to/component2";\\s*` +
+				`import { Component2 } from "./to/component2";\\s*` +
 				`const routes: Routes = \\[\\s*` +
 				`{ existing },\\s*` +
 				`{ path: "href", component: Component1, data: { text: "text" } }\\s*` +
 				`\\];\\s*` +
 				`const routes2: Routes = \\[{ path: "href2", component: Component2, data: { text: "text2" } }\\];`
+			)
+		);
+		expect(formatSpy).toHaveBeenCalledTimes(2);
+		done();
+	});
+
+	fit("Adds child routes", async done => {
+		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
+			ts.createSourceFile("route-module.ts", `
+				const routes: Routes = [
+					{ path: 'parent', component: ParentComponent }
+				];
+			`, ts.ScriptTarget.Latest, true),
+			{ getChildren: () => ["component1"] },
+			{ getChildren: () => ["component2"] }
+		);
+		spyOn(fs, "writeFileSync");
+		const formatSpy = spyOn(TypeScriptFileUpdate.prototype as any, "formatFile");
+		spyOn(TypeScriptUtils, "getClassName").and.returnValues("Component1", "Component2");
+		spyOn(Util, "relativePath").and.returnValues("./to/component", "./to/component2");
+
+		const tsUpdate = new TypeScriptFileUpdate("route-module.ts");
+
+		// call when parent route has no child routes
+		tsUpdate.addChildRoute("path/to/component", "child-1", "parent");
+		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component", true, true);
+		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component1"]);
+		expect(fs.writeFileSync).toHaveBeenCalledWith(
+			"route-module.ts",
+			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
+				`const routes: Routes = \\[\\s*` +
+				`{ path: 'parent', component: ParentComponent, children:\\s*` +
+				`\\[\\{ path: "child-1", component: Component1 }\\]\\ }\\s*` +
+				`\\];\\s*`
+			)
+		);
+		expect(formatSpy).toHaveBeenCalled();
+
+		// call when parent route has child routes
+		tsUpdate.addChildRoute("path/to/component2", "child-2", "parent");
+		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component2", true, true);
+		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component2"]);
+		expect(fs.writeFileSync).toHaveBeenCalledWith(
+			"route-module.ts",
+			jasmine.stringMatching(`import { Component1 } from "./to/component";\\s*` +
+				`import { Component2 } from "./to/component2";\\s*` +
+				`const routes: Routes = \\[\\s*` +
+				`{ path: 'parent', component: ParentComponent, children:\\s*` +
+				`\\[\\{ path: "child-1", component: Component1 }, { path: "child-2", component: Component2 }\\]\\ }\\s*` +
+				`\\];\\s*`
 			)
 		);
 		expect(formatSpy).toHaveBeenCalledTimes(2);
@@ -253,10 +304,10 @@ describe("Unit - TypeScriptFileUpdate", () => {
 					`import { SomeModule, GridModule2 } from "another/package";`,
 					`@NgModule({`,
 					`imports: [`,
-						"Named,",
-						"SomeModule,",
-						"GridModule,",
-						"GridModule2.forRoot()",
+					"Named,",
+					"SomeModule,",
+					"GridModule,",
+					"GridModule2.forRoot()",
 					"]",
 					"})",
 					"export class TestModule {", "}"
@@ -287,7 +338,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			const tsUpdate = new TestTsFileUpdate("/test/file");
 			tsUpdate.addNgModuleMeta({ import: "Named", from: "package" }); //reuse import
 			tsUpdate.addNgModuleMeta({ declare: "Component1", from: "another/package" });
-			tsUpdate.addNgModuleMeta({ import: "Module1", declare:  [ "Component2" ], provide: "GridService" }); // no import
+			tsUpdate.addNgModuleMeta({ import: "Module1", declare: ["Component2"], provide: "GridService" }); // no import
 			tsUpdate.finalize();
 
 			expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -296,17 +347,17 @@ describe("Unit - TypeScriptFileUpdate", () => {
 					`import { SomeModule, Component1 } from "another/package";`,
 					`@NgModule({`,
 					`imports: [`,
-						"SomeModule,",
-						"Named,",
-						"Module1",
+					"SomeModule,",
+					"Named,",
+					"Module1",
 					"],",
 					`declarations: [`,
-						"Component1,",
-						"Component2",
+					"Component1,",
+					"Component2",
 					"],",
 					`providers: [`,
-						"Service,",
-						"GridService",
+					"Service,",
+					"GridService",
 					"]",
 					"})",
 					"export class TestModule {", "}"
@@ -331,7 +382,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			const tsUpdate = new TestTsFileUpdate("/test/file");
 			tsUpdate.addNgModuleMeta({ import: "Named" });
 			tsUpdate.addNgModuleMeta({ declare: "Component1" });
-			tsUpdate.addNgModuleMeta({ import: "Module1", declare:  [ "Component2" ], provide: "GridService" });
+			tsUpdate.addNgModuleMeta({ import: "Module1", declare: ["Component2"], provide: "GridService" });
 			tsUpdate.finalize();
 
 			expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -339,15 +390,15 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				jasmine.stringMatching([
 					`@NgModule({`,
 					`declarations: [`,
-						"Component1,",
-						"Component2",
+					"Component1,",
+					"Component2",
 					"],",
 					`imports: [`,
-						"Named,",
-						"Module1",
+					"Named,",
+					"Module1",
 					"],",
 					`providers: [`,
-						"GridService",
+					"GridService",
 					"]",
 					"})",
 					"export class TestModule {", "}"
@@ -366,8 +417,8 @@ describe("Unit - TypeScriptFileUpdate", () => {
 
 			const configVariables = {
 				"$(key)": "Replace",
-				"$(key2)" : "Replace2",
-				"$(key3)" : "Replace3",
+				"$(key2)": "Replace2",
+				"$(key3)": "Replace3",
 				"__key4__": "replace4",
 				"__key5__": "replace5"
 			};
@@ -384,9 +435,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				["ReplaceModule", "Replace2Component", "Replace3Component"], "replace4"
 			);
 			tsUpdate.addNgModuleMeta({
-				import: [ "$(key)Module", "$(key2)Module"],
+				import: ["$(key)Module", "$(key2)Module"],
 				declare: "$(key3)Component",
-				provide: [ "$(key)Service" ],
+				provide: ["$(key)Service"],
 				from: "./src/__key4__/__key5__.service"
 			}, configVariables);
 			expect(TestTsFileUpdate.prototype.requestImport).toHaveBeenCalledWith(
@@ -478,18 +529,18 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		testTslint = {
 			rules: {
 				"prefer-const": true,
-				"quotemark": [ true, "single" ]
+				"quotemark": [true, "single"]
 			}
 		};
 		tsUpdate.readFormatConfigs();
 		expect(tsUpdate.getFormatting().singleQuotes).toEqual(true);
 
-		testTslint.rules["indent"] = [ true, "spaces", 4 ];
+		testTslint.rules["indent"] = [true, "spaces", 4];
 		tsUpdate.readFormatConfigs();
 		expect(tsUpdate.getFormatting().indentSize).toEqual(4);
 		expect(tsUpdate.getFormatting().spaces).toEqual(true);
 
-		testTslint.rules["indent"] = [ true, "tabs", 2 ];
+		testTslint.rules["indent"] = [true, "tabs", 2];
 		tsUpdate.readFormatConfigs();
 		expect(tsUpdate.getFormatting().indentSize).toEqual(2);
 		expect(tsUpdate.getFormatting().spaces).toEqual(false);

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -1,4 +1,4 @@
-import { App, GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
+import { GoogleAnalytics, TypeScriptFileUpdate, TypeScriptUtils, Util } from "@igniteui/cli-core";
 import * as fs from "fs";
 import * as ts from "typescript";
 
@@ -254,7 +254,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		const tsUpdate = new TypeScriptFileUpdate("route-module.ts");
 
 		// call when parent route has no child routes
-		tsUpdate.addRoute("path/to/component", "child-1", "child one", "", "parent");
+		tsUpdate.addChildRoute("path/to/component", "child-1", "child one", "parent");
 		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component", true, true);
 		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component1"]);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -269,7 +269,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		expect(formatSpy).toHaveBeenCalled();
 
 		// call when parent route has child routes
-		tsUpdate.addRoute("path/to/component2", "child-2", "child two", "", "parent");
+		tsUpdate.addChildRoute("path/to/component2", "child-2", "child two", "parent");
 		expect(Util.relativePath).toHaveBeenCalledWith("route-module.ts", "path/to/component2", true, true);
 		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component2"]);
 		expect(fs.writeFileSync).toHaveBeenCalledWith(

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -11,14 +11,21 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		it("Create with source file", async done => {
 			class TestTsFileUpdate extends TypeScriptFileUpdate {
 				public initState() {
+					super.initState();
+				}
+
+				public loadImportsMeta() {
+					return null;
 				}
 			}
 			spyOn(TypeScriptUtils, "getFileSource");
-			spyOn(TestTsFileUpdate.prototype, "initState");
-
+			spyOn(TestTsFileUpdate.prototype, "loadImportsMeta");
+			spyOn(TestTsFileUpdate.prototype, "initState").and.callThrough();
 			const tsUpdate = new TestTsFileUpdate("/test/file");
+
 			expect(TypeScriptUtils.getFileSource).toHaveBeenCalledWith("/test/file");
 			expect(TestTsFileUpdate.prototype.initState).toHaveBeenCalled();
+			expect(TestTsFileUpdate.prototype.loadImportsMeta).toHaveBeenCalled();
 			done();
 		});
 


### PR DESCRIPTION
Add the option for `TsFileUpdateUtil.AddRoute` to add route entries as children of an existing route path.
If `parentRoutePath` parameter (new, optional) is passed, the generated route entry will be added in the `children` array of the route matching the provided path.
