### PR TITLE
fix(dock-manager): Use correct module name in app.module import

### DIFF
--- a/packages/igx-templates/igx-ts/dock-manager/default/index.ts
+++ b/packages/igx-templates/igx-ts/dock-manager/default/index.ts
@@ -13,7 +13,7 @@ class IgcDockManagerTemplate extends IgniteUIForAngularTemplate {
 		this.name = "Dock Manager";
 		this.description = "basic IgcDockManager";
 		this.dependencies = [
-			{ import: "DockManagerModule", from: "./src/app/<%=path%>/<%=filePrefix%>.module.ts" }
+			{ import: "<%=ClassName%>Module", from: "./src/app/<%=path%>/<%=filePrefix%>.module.ts" }
 		];
 		// "igniteui-dockmanager@~1.0.0":
 		this.packages = [ `${resolveIgxPackage(NPM_DOCK_MANAGER)}@~1.0.0"` ];


### PR DESCRIPTION
Closes #792 .  

Additional information related to this pull request:

