### PR TITLE
fix(angular-templates): fix some issue with strict templates in igx-ts, add strict to tsconfig

### DIFF
--- a/packages/igx-templates/igx-ts/autocomplete/autocomplete-extended/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/autocomplete/autocomplete-extended/files/src/app/__path__/__filePrefix__.component.ts
@@ -20,13 +20,16 @@ export class <%=ClassName%>Component {
     this.regions = townsExtended;
   }
 
-  public getPostalCode(e: ISelectionEventArgs) {
+  public getPostalCode(e: ISelectionEventArgs): void {
 
     // Flatten the structure of the regions array
-    const allTowns = this.regions.map(region =>
-      region.towns).flat();
+    const allTowns = this.regions.map(region => region.towns).reduce((prev, curr) => curr.concat(...prev), []);
 
     const townEntry = allTowns.find(t => t.name === e.newSelection.value);
+
+    if (!townEntry) {
+        return;
+    } 
 
     this.postalCode = townEntry.postalCode;
     this.toast.open();

--- a/packages/igx-templates/igx-ts/autocomplete/autocomplete-extended/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/autocomplete/autocomplete-extended/files/src/app/__path__/__filePrefix__.component.ts
@@ -10,7 +10,7 @@ import { IgxToastComponent, IgxToastPosition, ISelectionEventArgs } from '<%=igx
 export class <%=ClassName%>Component {
   public regions!: Region[];
   public townSelected!: string;
-  public postalCode!: number | 'none';
+  public postalCode?: number;
   public messagePosition = IgxToastPosition.Middle;
 
   @ViewChild(IgxToastComponent, { static: true })
@@ -23,15 +23,11 @@ export class <%=ClassName%>Component {
   public getPostalCode(e: ISelectionEventArgs): void {
 
     // Flatten the structure of the regions array
-    const allTowns = this.regions.map(region => region.towns).reduce((prev, curr) => curr.concat(...prev), []);
+    const allTowns = this.regions.map(region => region.towns).reduce((prev, curr) => prev.concat(curr), []);
 
     const townEntry = allTowns.find(t => t.name === e.newSelection.value);
 
-    if (!townEntry) {
-        return;
-    } 
-
-    this.postalCode = townEntry.postalCode;
+    this.postalCode = townEntry?.postalCode;
     this.toast.open();
   }
 }

--- a/packages/igx-templates/igx-ts/combo/default/files/src/app/__path__/__filePrefix__.component.ts
+++ b/packages/igx-templates/igx-ts/combo/default/files/src/app/__path__/__filePrefix__.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { IgxComboComponent  } from '<%=igxPackage%>';
+import { Component, OnInit } from '@angular/core';
 import { localData  } from './local-data';
 
 @Component({

--- a/packages/igx-templates/igx-ts/combo/default/files/src/app/__path__/local-data.ts
+++ b/packages/igx-templates/igx-ts/combo/default/files/src/app/__path__/local-data.ts
@@ -1,4 +1,4 @@
-const division = {
+const division: { [key: string]: string[] } = {
     'New England 01': ['Connecticut', 'Maine', 'Massachusetts'],
     'New England 02': ['New Hampshire', 'Rhode Island', 'Vermont'],
     'Mid-Atlantic': ['New Jersey', 'New York', 'Pennsylvania'],

--- a/packages/igx-templates/igx-ts/hierarchical-grid/hierarchical-grid-batch-editing/files/src/app/__path__/data.ts
+++ b/packages/igx-templates/igx-ts/hierarchical-grid/hierarchical-grid-batch-editing/files/src/app/__path__/data.ts
@@ -93,7 +93,6 @@ export const SINGERS: Singer[] = [
         Songs: [{
           Number: 1,
           Title: "Intro",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
@@ -114,7 +113,6 @@ export const SINGERS: Singer[] = [
         {
           Number: 4,
           Title: "Future past",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
@@ -135,14 +133,12 @@ export const SINGERS: Singer[] = [
         {
           Number: 7,
           Title: "Stay where you are",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
         {
           Number: 8,
           Title: "Imaginarium",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
@@ -156,21 +152,18 @@ export const SINGERS: Singer[] = [
         {
           Number: 10,
           Title: "Shredded into pieces",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
         {
           Number: 11,
           Title: "Capture this moment",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         },
         {
           Number: 12,
           Title: "Dream Driven",
-          Released: null,
           Genre: "*",
           Album: "Dream Driven"
         }]

--- a/packages/igx-templates/igx-ts/hierarchical-grid/hierarchical-grid-batch-editing/files/src/app/__path__/singer.ts
+++ b/packages/igx-templates/igx-ts/hierarchical-grid/hierarchical-grid-batch-editing/files/src/app/__path__/singer.ts
@@ -2,7 +2,7 @@
 export interface Song {
   Number: number;
   Title: string;
-  Released: Date;
+  Released?: Date;
   Genre: string;
   Album: string;
 }

--- a/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.component.html
@@ -28,7 +28,7 @@
         #linearGauge
         height="80px"
         width="100%"
-        [minimumValue]=""
+        [minimumValue]="0"
         [maximumValue]="10"
         [value]="5"
         [interval]="1"

--- a/packages/igx-templates/igx-ts/list/default/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/list/default/files/src/app/__path__/__filePrefix__.component.html
@@ -8,7 +8,7 @@
     <igx-icon>search</igx-icon>
   </igx-prefix>
   <input #search igxInput placeholder="Search Contacts" [(ngModel)]="searchContact">
-  <igx-suffix *ngIf="search.value.length > 0" (click)="searchContact = null">
+  <igx-suffix *ngIf="search.value.length > 0" (click)="searchContact = ''">
     <igx-icon>clear</igx-icon>
   </igx-suffix>
 </igx-input-group>

--- a/packages/igx-templates/igx-ts/projects/_base/files/tsconfig.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
+    "strict": true,
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Add "compilerOptions.strict: true" to tsconfig.json.
Address some issues w/ `strictTemplates`.
Address some issues from strict typescript options.
Update `enhanced-autocomplete` to use `arr.reduce` instead of `arr.flat`, as `arr.flat` requires `es2019`, but default (in latest ng new proj) is `es2018`

