### PR TITLE
fix(igx-ts): use explicit index in drop-down components for logic view

### DIFF
--- a/packages/igx-templates/igx-ts/projects/side-nav-auth/files/src/app/authentication/login-bar/login-bar.component.html
+++ b/packages/igx-templates/igx-ts/projects/side-nav-auth/files/src/app/authentication/login-bar/login-bar.component.html
@@ -10,8 +10,8 @@
 </button>
 
 <igx-drop-down #options (selectionChanging)="menuSelect($event)">
-  <igx-drop-down-item igxRipple>Profile</igx-drop-down-item>
-  <igx-drop-down-item igxRipple>Log Out</igx-drop-down-item>
+  <igx-drop-down-item [index]="0" igxRipple>Profile</igx-drop-down-item>
+  <igx-drop-down-item [index]="1" igxRipple>Log Out</igx-drop-down-item>
 </igx-drop-down>
 
 <app-login-dialog></app-login-dialog>


### PR DESCRIPTION
Logic drop-down was using `IgxDropDownItemComponent.index` property w/o implicitly setting it, causing a deprecation warning

