### PR TITLE
fix(igx-ts): remove deprecated properties from scenario templates

### DIFF
--- a/.vscode/tasks.json.old
+++ b/.vscode/tasks.json.old
@@ -1,0 +1,24 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "0.1.0",
+	"command": "npm",
+	"isShellCommand": true,
+	"suppressTaskName": true,
+	"tasks": [
+        {
+        // Build task, Ctrl+Shift+B
+        // "npm run build"
+        "taskName": "build",
+        "isBuildCommand": true,
+        "args": ["run", "build"]
+        },
+        {
+        // Test task, Ctrl+Shift+T
+        // "npm test"
+        "taskName": "test",
+        "isTestCommand": true,
+        "args": ["test"]
+        }
+    ]
+}

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.html
@@ -5,12 +5,12 @@
         <igx-switch [checked]="true" [(ngModel)]="theme" (change)="onThemeChanged($event)">Dark</igx-switch>
       </div>
       <div class="control-item">
-        <igx-switch [checked]="grouped" (change)="onChange($event)" color="blue"
+        <igx-switch [checked]="grouped" (change)="onChange($event)"
           cssClass="fintech-sample-switch">
           Grouped</igx-switch>
       </div>
       <div class="control-item">
-        <igx-switch [checked]="showToolbar" (change)="toggleToolbar()" color="blue"
+        <igx-switch [checked]="showToolbar" (change)="toggleToolbar()"
           cssClass="fintech-sample-switch">Toolbar</igx-switch>
       </div>
       <div class="fintech-slider control-item">

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.html
@@ -53,8 +53,8 @@
       <ng-template igxCell let-cell="cell">
         <div class="finjs-icons">
           <span>{{cell.value | currency:'USD':'symbol':'1.4-4'}}</span>
-          <igx-icon *ngIf="trends.positive(cell.row.rowData)">trending_up</igx-icon>
-          <igx-icon *ngIf="trends.negative(cell.row.rowData)">trending_down</igx-icon>
+          <igx-icon *ngIf="trends.positive(cell.row.data)">trending_up</igx-icon>
+          <igx-icon *ngIf="trends.negative(cell.row.data)">trending_down</igx-icon>
         </div>
       </ng-template>
     </igx-column>

--- a/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-tree-grid/files/src/app/__path__/__filePrefix__.component.html
@@ -5,7 +5,7 @@
         <igx-switch [checked]="true" [(ngModel)]="theme" (change)="onThemeChanged($event)">Dark</igx-switch>
       </div>
       <div class="control-item">
-        <igx-switch [checked]="true" (change)="toggleToolbar()" color="blue" cssClass="finjs-sample-switch">Toolbar</igx-switch>
+        <igx-switch [checked]="true" (change)="toggleToolbar()" cssClass="finjs-sample-switch">Toolbar</igx-switch>
       </div>
       <div class="finjs-slider control-item">
         <label for="slider">Records: {{volume}}</label>

--- a/packages/igx-templates/igx-ts/custom-templates/weather-forecast/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/custom-templates/weather-forecast/files/src/app/__path__/__filePrefix__.component.html
@@ -8,11 +8,11 @@
     <div class="weather__main" *ngIf=data>
       <div class="weather__main-temp">
       <div>{{data.today.tempMax}}°<sup>C</sup></div>
-      <div class="right"><igx-icon color="orange" family="fas" name="fa-sun"></igx-icon></div>
+      <div class="right"><igx-icon class="weather-icon--orange" family="fas" name="fa-sun"></igx-icon></div>
       </div>
       <div class="weather__main-hum">
-      <div><igx-icon color="blue" family="fas" name="fa-umbrella"></igx-icon>{{data.precipitation}} Precipitation </div>
-      <div class="right"><igx-icon color="aqua-blue" family="fas" name="fa-tint"></igx-icon>{{data.humidity}} Humidity </div>
+      <div><igx-icon class="weather-icon--blue" family="fas" name="fa-umbrella"></igx-icon>{{data.precipitation}} Precipitation </div>
+      <div class="right"><igx-icon class="weather-icon--skyblue" family="fas" name="fa-tint"></igx-icon>{{data.humidity}} Humidity </div>
       </div>
     </div>
     <button igxButton igxRipple (click)="toggleDetails()">Forecast Details</button>
@@ -22,7 +22,7 @@
         <div *ngFor="let day of data.daysOfWeek" class="forecast__day">
         <div>{{day.name}}</div>
         <div class="right">
-          <igx-icon [color]="day.iconColor" family="fas" [name]="day.iconName" font-size="1em"></igx-icon>
+          <igx-icon [ngClass]="'weather-icon--' + day.iconColor" family="fas" [name]="day.iconName" font-size="1em"></igx-icon>
           {{day.tempMin}}°/{{day.tempMax}}°
         </div>
         </div>

--- a/packages/igx-templates/igx-ts/custom-templates/weather-forecast/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/custom-templates/weather-forecast/files/src/app/__path__/__filePrefix__.component.scss
@@ -27,6 +27,21 @@
     text-align: right;
 }
 
+igx-icon.weather-icon {
+    &--gray {
+        color: gray;
+    }
+    &--blue {
+        color: blue;
+    }
+    &--orange {
+        color: orange;
+    }
+    &--skyblue {
+        color: skyblue;
+    }
+}
+
 .weather__main-temp {
     @extend %columnDisplay;
     font-size: 4rem;

--- a/packages/igx-templates/igx-ts/grid/grid-custom/files/src/app/__path__/__filePrefix__.component.html
+++ b/packages/igx-templates/igx-ts/grid/grid-custom/files/src/app/__path__/__filePrefix__.component.html
@@ -3,7 +3,7 @@ You can read more about configuring the igx-grid component in the
 <a href="https://github.com/IgniteUI/igniteui-angular/blob/master/projects/igniteui-angular/src/lib/grids/README.md" target="_blank">README</a> or the
 <a href="https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/grid" target="_blank">official documentation</a>.</p>
 <%=selectedFeatures%>
-<igx-grid #grid1 [data]="localData" [primaryKey]="'EmployeeID'" width="900px" height="550px" <%=gridFeatures%>>
+<igx-grid #grid1 [data]="localData" primaryKey="EmployeeID" width="900px" height="550px" <%=gridFeatures%>>
   <igx-column field="FirstName" header="First Name"  width="150px" <%=columnFeatures%> <%=columnPinning%>>
   </igx-column>
   <igx-column field="LastName" header="Last Name" width="150px" <%=columnFeatures%> <%=columnPinning%>>


### PR DESCRIPTION
Some icons were using the deprecated 'color' property
Rename referance from `cell.row.rowData` => `cell.row.data`

