### PR TITLE
fix(schematics): resolve schema id deprecation warning

### DIFF
--- a/packages/ng-schematics/src/component/schema.json
+++ b/packages/ng-schematics/src/component/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularComponent",
+  "$id": "SchematicsAngularComponent",
   "title": "Angular Component Options Schema",
   "type": "object",
   "description": "Creates a new Ignite UI for Angular component in the given or default project.",

--- a/packages/ng-schematics/src/ng-new/schema.json
+++ b/packages/ng-schematics/src/ng-new/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularNgNew",
+  "$id": "SchematicsAngularNgNew",
   "title": "Ignite UI for Angular Ng New Options Schema",
   "type": "object",
   "properties": {

--- a/packages/ng-schematics/src/upgrade-packages/schema.json
+++ b/packages/ng-schematics/src/upgrade-packages/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "SchematicsAngularNgNew",
+  "$id": "SchematicsAngularNgNew",
   "title": "Ignite UI for Angular Upgrade packages Options Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Fixing an error shown when executing `ng g @igniteui/angular-schematics:c` in a project.
![image](https://user-images.githubusercontent.com/9549439/127858248-ed87a98c-ca14-4aac-b883-79ba07517e77.png)


