### PR TITLE
NavDrawer view is now HTMLElement instead of lit

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/index.html
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/index.html
@@ -30,7 +30,7 @@
 </head>
 
 <body>
-  <lit-app></lit-app>
+  <app-navigation></app-navigation>
   <main id="outlet"></main>
 
   <script type="module" src="./dist/src/index.js"></script>

--- a/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/src/app.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/src/app.ts
@@ -1,19 +1,16 @@
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
 import 'igniteui-webcomponents';
 import { routes } from './index.js';
 import './app/home/home.component';
 import './app/not-found/not-found.component';
 
-@customElement('lit-app')
-export class App extends LitElement {
-  render() {
-    return html`
+export class App extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
     <div id="navigation-outlet">
       <igc-nav-drawer open=true>
         <igc-nav-drawer-header-item>Ignite UI CLI</igc-nav-drawer-header-item>
 
-        ${routes.filter((element, index) => index < routes.length - 1).map(i => html`
+        ${routes.filter((element, index) => index < routes.length - 1).map(i => this.innerHTML = `
           <igc-nav-drawer-item>
             <span slot="content">
               <a href="${i.path}">${i.name}</a>
@@ -25,3 +22,5 @@ export class App extends LitElement {
     `;
   }
 }
+
+customElements.define('app-navigation', App);


### PR DESCRIPTION
Making the NavDrawer component an HTMLElement instead of lit-element so that the global theme can make it through the shadow dom.
