### PR TITLE
chore: only patch updates for typescript

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/empty/files/package.json
@@ -39,7 +39,7 @@
     "igniteui-cli": "$(cliVersion)",
     "eslint": "^7.32.0",
     "tslib": "^2.3.1",
-    "typescript": "^4.4.2"
+    "typescript": "~4.4.4"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
Until CLI is compatible with TypeScript 4.5.x we need to stick to 4.4.x