### PR TITLE
fix(fintech grid): fix slow grid #1020

### DIFF
--- a/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.scss
+++ b/packages/igx-templates/igx-ts/custom-templates/fintech-grid/files/src/app/__path__/__filePrefix__.component.scss
@@ -229,7 +229,6 @@
 
 @include core();
 @include typography($font-family: $material-typeface, $type-scale: $material-type-scale);
-@include theme($default-palette);
 
 
 @include scrollbar-love();


### PR DESCRIPTION
Closes #1020 

Removed `@include theme($default-palette);` from the template because it was slowing down the performance of the grid.

