### PR TITLE
refactor(theme-import): Place sass/scss imports before content.

### DIFF
--- a/packages/ng-schematics/src/utils/theme-import.ts
+++ b/packages/ng-schematics/src/utils/theme-import.ts
@@ -43,7 +43,7 @@ function importDefaultThemeSass(tree: Tree, filePath: string) {
 	const igxPackage = resolveIgxPackage(NPM_PACKAGE);
 	const sassImports =
 	`
-@use "~${igxPackage}/theming";
+@use "~${igxPackage}/theming" as *;
 // Uncomment the following lines if you want to add a custom palette:
 // $primary: #731963 !default;
 // $secondary: #ce5712 !default;
@@ -59,7 +59,7 @@ function importDefaultThemeSass(tree: Tree, filePath: string) {
 	let content = tree.read(filePath)!.toString();
 
 	if (!content.includes(sassImports)) {
-		content += sassImports;
+		content = sassImports + content;
 	}
 
 	tree.overwrite(filePath, content);


### PR DESCRIPTION
After testing we found a problem where the `@use` wasn't at the beginning of the file and `as *` was also missing.

