### PR TITLE
ig update implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -178,6 +178,22 @@
 		{
 			"type": "node",
 			"request": "launch",
+			"name": "Launch Update",
+			"program": "${workspaceRoot}/packages/cli/bin/execute.js",
+			"console": "externalTerminal",
+			"preLaunchTask": "build",
+			"outFiles": ["${workspaceFolder}/**/*.js"],
+			// make sure to npm link igniteui-cli to the project that is cwd
+			// otherwise the command will be executed from project/node_modules/igniteui-cli
+			"cwd": "${workspaceRoot}/output/IG-Project",
+			"args": [
+				"update",
+				// "igniteui-webcomponents@^13",
+			]
+		},
+		{
+			"type": "node",
+			"request": "launch",
 			"name": "Add Combo to Jquery",
 			"cwd": "${workspaceRoot}/output/jqueryproj",
 			"program": "${workspaceRoot}/packages/cli/bin/execute.js",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -188,7 +188,7 @@
 			"cwd": "${workspaceRoot}/output/IG-Project",
 			"args": [
 				"update",
-				// "igniteui-webcomponents@^13",
+				"igniteui-webcomponents",
 			]
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"fs-extra": "^3.0.1",
 		"glob": "^7.1.2",
 		"inquirer": "^6.4.1",
-		"jasmine": "3.5.0",
+		"jasmine": "^4.4.0",
 		"jasmine-spec-reporter": "^4.2.1",
 		"lerna": "^3.16.4",
 		"lerna-changelog": "^0.8.2",
@@ -79,7 +79,7 @@
 		"source-map-support": "^0.5.4",
 		"ts-node": "^6.2.0",
 		"tslint": "^5.11.0",
-		"typescript": "~4.5.2",
+		"typescript": "^4.9.0-dev.20220914",
 		"typescript-json-schema": "^0.42.0"
 	},
 	"workspaces": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@types/fs-extra": "^3.0.3",
 		"@types/inquirer": "0.0.35",
 		"@types/jasmine": "3.3.9",
-		"@types/node": "^8.10.0",
+		"@types/node": "^14.18.27",
 		"browser-sync": "^2.26.3",
 		"coveralls": "^3.0.0",
 		"fs-extra": "^3.0.1",

--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -10,9 +10,10 @@ import { default as newCommand } from "./commands/new";
 import { default as quickstart } from "./commands/quickstart";
 import { default as start } from "./commands/start";
 import { default as test } from "./commands/test";
+import { default as update } from "./commands/update";
 import { default as upgrade } from "./commands/upgrade";
 import { PromptSession } from "./PromptSession";
-import {TemplateManager} from "./TemplateManager";
+import { TemplateManager } from "./TemplateManager";
 
 process.title = "Ignite UI CLI";
 
@@ -38,6 +39,7 @@ export async function run(args = null) {
 	generate.templateManager = templateManager;
 	list.templateManager = templateManager;
 	upgrade.templateManager = templateManager;
+	update.templateManager = templateManager;
 
 	const yargsModule = args ? yargs(args) : yargs;
 
@@ -53,6 +55,7 @@ export async function run(args = null) {
 	.command(test)
 	.command(list)
 	.command(upgrade)
+	.command(update)
 	.options({
 		version: {
 			alias: "v",
@@ -118,6 +121,9 @@ export async function run(args = null) {
 			break;
 		case "upgrade-packages":
 			await upgrade.execute(argv);
+			break;
+		case "update":
+			await update.execute(argv);
 			break;
 		default:
 			Util.log("Starting Step by step mode.", "green");

--- a/packages/cli/lib/commands/update.ts
+++ b/packages/cli/lib/commands/update.ts
@@ -1,0 +1,58 @@
+//tslint:disable:ordered-imports
+import { GoogleAnalytics, ProjectConfig, Util } from "@igniteui/cli-core";
+
+// tslint:disable:object-literal-sort-keys
+const command = {
+	command: "update [package] [version]",
+	desc: "updates a package or lists packages for update",
+	templateManager: null,
+	builder: {
+		package: {
+			alias: "p",
+			description: "Package to update.",
+			global: true,
+			type: "string"
+		}
+	},
+	async execute(argv: any) {
+		GoogleAnalytics.post({
+			t: "screenview",
+			cd: "Update"
+		});
+
+		if (!ProjectConfig.hasLocalConfig()) {
+			Util.error("Update command is supported only on existing project created with igniteui-cli", "red");
+			return;
+		}
+
+		if (!Util.checkWorkingTreeIsClean()) {
+			Util.error("Update command can only be executed on a clean Git state", "red");
+			return;
+		}
+
+		const config = ProjectConfig.getConfig();
+		const framework = command.templateManager.getFrameworkById(config.project.framework);
+		if (!framework) {
+			Util.error("Framework not supported", "red");
+			return;
+		}
+
+		if (!argv.package) {
+			// ig update
+			const pkgsToUpdate = await Util.lookUpPackagesForUpdate(config);
+			Util.listPackagesForUpdate(pkgsToUpdate);
+			return;
+		}
+
+		// ig update <package>[@<version>]
+		const [name, version] = argv.package.split("@");
+		if (!version) {
+			// TODO
+			return;
+		}
+
+		// TODO
+	}
+};
+
+export default command;

--- a/packages/cli/lib/commands/update.ts
+++ b/packages/cli/lib/commands/update.ts
@@ -47,6 +47,12 @@ const command = {
 
 		// ig update <package>[@<version>]
 		const [name, version] = argv.package.split("@");
+		if (framework === "angular") {
+			// proxy to ng update for angular projects
+			Util.execSync(`ng update ${name}${version ? `@${version}` : ""}`);
+			return;
+		}
+
 		if (!version) {
 			const installedPackage = Util.locatePackageFromDependencies(config, name);
 			if (!installedPackage) {
@@ -54,26 +60,27 @@ const command = {
 				return;
 			}
 
-			const pkgData = await Util.getPackageMetadata(name);
-			const remotePkgLatest = semver.coerce(pkgData["dist-tags"].latest);
-			if (remotePkgLatest === installedPackage.version) {
-				Util.error(`Package ${name} is already up to date`);
-				return;
-			}
+			const remotePkgLatest = semver.coerce("6.0.0"); // TODO: remove
+			// const pkgData = await Util.getPackageMetadata(name);
+			// const remotePkgLatest = semver.coerce(pkgData["dist-tags"].latest);
+			// if (remotePkgLatest === installedPackage.version) {
+			// 	Util.error(`Package ${name} is already up to date`);
+			// 	return;
+			// }
 
-			// update to latest version of package
-			let success = Util.cleanNodeModules() && await Util.installAllDeps();
-			if (!success) {
-				return;
-			}
+			// // update to latest version of package
+			// let success = Util.cleanNodeModules() && await Util.installAllDeps();
+			// if (!success) {
+			// 	return;
+			// }
 
-			success = Util.tryInstallPackage(Util.getPackageManager(), `${name}@latest`);
-			if (!success) {
-				return;
-			}
+			// success = Util.tryInstallPackage(Util.getPackageManager(), `${name}@latest`);
+			// if (!success) {
+			// 	return;
+			// }
 
 			// invoke migrations from current pkg ver to latest
-
+			await Util.invokeMigrationsBetweenVersions(installedPackage, remotePkgLatest);
 			return;
 		}
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,8 @@
     "resolve": "^1.6.0",
     "through2": "^2.0.3",
     "typescript": "~4.5.2",
-    "yargs": "^8.0.2"
+    "yargs": "^8.0.2",
+	"semver": "~5.7.1"
   },
   "devDependencies": {
     "@angular-devkit/core": "~14.0.0",

--- a/packages/cli/templates/angular/index.ts
+++ b/packages/cli/templates/angular/index.ts
@@ -13,4 +13,5 @@ class AngularFramework implements Framework {
 		this.projectLibraries.push(require("./ig-ts") as ProjectLibrary);
 	}
 }
-export = new AngularFramework() as Framework;
+
+export const factory = () => new AngularFramework() as Framework;

--- a/packages/cli/templates/jquery/index.ts
+++ b/packages/cli/templates/jquery/index.ts
@@ -13,4 +13,5 @@ class jQueryFramework implements Framework {
 		this.projectLibraries.push(require("./js") as ProjectLibrary);
 	}
 }
-export = new jQueryFramework() as Framework;
+
+export const factory = () => new jQueryFramework() as Framework;

--- a/packages/cli/templates/react/index.ts
+++ b/packages/cli/templates/react/index.ts
@@ -13,4 +13,5 @@ class ReactFramework implements Framework {
 		this.projectLibraries.push(require("./igr-es6") as ProjectLibrary);
 	}
 }
-export = new ReactFramework() as Framework;
+
+export const factory = () => new ReactFramework() as Framework;

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/ignite-ui-cli.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/ignite-ui-cli.json
@@ -10,7 +10,8 @@
 		"components": [],
 		"sourceFiles": [],
 		"isShowcase": false,
-		"version": ""
+		"version": "",
+		"sourceRoot": "./"
 	},
 	"build": {}
 }

--- a/packages/cli/templates/webcomponents/index.ts
+++ b/packages/cli/templates/webcomponents/index.ts
@@ -12,4 +12,5 @@ class WebComponentsFramework implements Framework {
 		this.projectLibraries.push(require("./igc-ts") as ProjectLibrary);
 	}
 }
-export = new WebComponentsFramework() as Framework;
+
+export const factory = () => new WebComponentsFramework() as Framework;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,11 @@
     "glob": "^7.1.2",
     "inquirer": "^6.2.2",
     "through2": "^2.0.3",
-    "typescript": "~4.5.2"
+    "typescript": "~4.5.2",
+	"type-fest": "~0.3.1",
+	"resolve": "~1.22.0",
+	"semver": "~5.7.1",
+	"axios": "~0.21.4"
   },
   "devDependencies": {
     "@angular-devkit/schematics": "~14.0.0"

--- a/packages/core/packages/PackageManager.ts
+++ b/packages/core/packages/PackageManager.ts
@@ -4,7 +4,7 @@ import { TemplateManager } from "../../cli/lib/TemplateManager";
 import { Config, FS_TOKEN, IFileSystem, ProjectTemplate } from "../types";
 import { App, ProjectConfig, Util } from "../util";
 
-import componentsConfig = require("./components");
+import componentsConfig from "./components";
 
 export class PackageManager {
 	private static ossPackage: string = "ignite-ui";

--- a/packages/core/packages/components.ts
+++ b/packages/core/packages/components.ts
@@ -1,4 +1,4 @@
-export = {
+export default {
 	dv: [
 		"igDataChart",
 		"igPieChart",

--- a/packages/core/templates/BaseTemplateManager.ts
+++ b/packages/core/templates/BaseTemplateManager.ts
@@ -12,8 +12,9 @@ export abstract class BaseTemplateManager {
 		const frameworks = Util.getDirectoryNames(this.templatesAbsPath)
 			.filter(x => x !== this._quickstartTemplatesPath);
 		// load and initialize templates
-		for (const framework of frameworks) {
-			this.frameworks.push(require(path.join(this.templatesAbsPath, framework)) as Framework);
+		for (const frameworkName of frameworks) {
+			const framework = require(path.join(this.templatesAbsPath, frameworkName));
+			this.frameworks.push(framework.factory());
 		}
 
 		// load external templates

--- a/packages/core/types/FileSystem.ts
+++ b/packages/core/types/FileSystem.ts
@@ -3,7 +3,7 @@ export interface IFileSystem {
 	readFile(filePath: string, encoding?: BufferEncoding): string;
 	writeFile(filePath: string, text: string): void;
 	directoryExists(dirPath: string): boolean;
-
+	removeDir?(dirPath: string, force: boolean, recursive?: boolean): boolean;
 	/**
 	 * Returns a list of file paths under a directory based on a match pattern
 	 * @param dirPath Root dir to search in

--- a/packages/core/types/FileSystem.ts
+++ b/packages/core/types/FileSystem.ts
@@ -1,6 +1,6 @@
 export interface IFileSystem {
 	fileExists(filePath: string): boolean;
-	readFile(filePath: string, encoding?: string): string;
+	readFile(filePath: string, encoding?: BufferEncoding): string;
 	writeFile(filePath: string, text: string): void;
 	directoryExists(dirPath: string): boolean;
 

--- a/packages/core/types/schema/index.ts
+++ b/packages/core/types/schema/index.ts
@@ -1,5 +1,5 @@
 export interface MigrationCollection {
-	migrations: Migration[]
+	migrations: Migration[];
 }
 
 export interface Migration {

--- a/packages/core/types/schema/index.ts
+++ b/packages/core/types/schema/index.ts
@@ -1,0 +1,9 @@
+export interface MigrationCollection {
+	migrations: Migration[]
+}
+
+export interface Migration {
+	name: string;
+	version: string;
+	factory: string;
+}

--- a/packages/core/types/schema/migration-collection.schema.json
+++ b/packages/core/types/schema/migration-collection.schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Migration": {
+            "properties": {
+                "factory": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "factory",
+                "name",
+                "version"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "migrations": {
+            "items": {
+                "$ref": "#/definitions/Migration"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "migrations"
+    ],
+    "type": "object"
+}
+

--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -12,9 +12,9 @@ export class FsFileSystem implements IFileSystem {
 			return false;
 		}
 	}
-	public readFile(filePath: string, encoding?: string): string {
+	public readFile(filePath: string, encoding?: BufferEncoding): string {
 		if (encoding) {
-			return fs.readFileSync(filePath, encoding);
+			return fs.readFileSync(filePath, { encoding });
 		}
 		return fs.readFileSync(filePath).toString();
 	}

--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -31,8 +31,8 @@ export class FsFileSystem implements IFileSystem {
 	public removeDir(dirPath: string, force: boolean, recursive = true): boolean {
 		try {
 			fs.rmSync(dirPath, {
-				force: force,
-				recursive: recursive,
+				force,
+				recursive,
 				maxRetries: 3
 			});
 			return true;

--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -28,6 +28,18 @@ export class FsFileSystem implements IFileSystem {
 			return false;
 		}
 	}
+	public removeDir(dirPath: string, force: boolean, recursive = true): boolean {
+		try {
+			fs.rmSync(dirPath, {
+				force: force,
+				recursive: recursive,
+				maxRetries: 3
+			});
+			return true;
+		} catch (err) {
+			return false;
+		}
+	}
 
 	public glob(dirPath: string, pattern: string): string[] {
 		return glob.sync(path.join(dirPath, pattern), { nodir: true });

--- a/packages/core/util/Typings.ts
+++ b/packages/core/util/Typings.ts
@@ -1,5 +1,7 @@
 import { PackageJson } from "type-fest";
 
+// TODO: move to core/types
+
 /**
  * Meant to contain configurations for the igniteui-cli
  * runtime operations

--- a/packages/core/util/Typings.ts
+++ b/packages/core/util/Typings.ts
@@ -1,0 +1,55 @@
+import { PackageJson } from "type-fest";
+
+/**
+ * Meant to contain configurations for the igniteui-cli
+ * runtime operations
+ */
+export interface IgCliConfig {
+	/**
+	 * Path to a json file that contains the migrations which need to be applied
+	 * by the ig update command
+	 */
+	migrations: string;
+}
+
+/**
+ * An extension over the base package.json model
+ */
+export interface PackageJsonExt extends PackageJson {
+	/**
+	 * igniteui-cli namespace in package.json
+	 * can be used for setting up configurations
+	 * that can be later used
+	 */
+	igCli?: IgCliConfig;
+}
+
+/**
+ * An npm package
+ */
+export interface Package {
+	/**
+	 * The name of the package
+	 */
+	name: string;
+
+	/**
+	 * The version of the package
+	 */
+	version: string;
+
+	/**
+	 * The version that the package will be updated to after ig update is ran
+	 */
+	versionAfterUpdate?: string;
+
+	/**
+	 * The absolute location of the package
+	 */
+	path: string;
+
+	/**
+	 * The package's package.json model
+	 */
+	package: PackageJsonExt | undefined;
+}

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -673,7 +673,7 @@ export class Util {
 	}
 
 	public static async invokeMigrationsBetweenVersions(installedPkg: Package, remotePkgVersion: string): Promise<void> {
-		let migColPath = path.normalize(`${installedPkg.path}/migrations/migration-collection.json`);
+		const migColPath = path.normalize(`${installedPkg.path}/migrations/migration-collection.json`);
 		if (Util.fileExists(migColPath)) {
 			const contents: MigrationCollection = JSON.parse(Util.readFile(migColPath));
 			const migrations = contents
@@ -682,9 +682,11 @@ export class Util {
 					&& semver.satisfies(semver.coerce(mig.version), `<=${remotePkgVersion}`));
 			for (const migration of migrations) {
 				try {
-					const factoryPath = path.normalize(path.join(migColPath.substring(0, migColPath.lastIndexOf("\\")), migration.factory)).replace(/\\/g, "/");
+					const factoryPath = path
+						.normalize(path.join(migColPath.substring(0, migColPath.lastIndexOf("\\")), migration.factory))
+						.replace(/\\/g, "/");
 					const { default: func } = await import(`${process.platform === "win32" ? "file://" : ""}${factoryPath}`);
-					// TODO
+					await func();
 				} catch (err) {
 					Util.error(`Migration ${migration.name} failed`);
 					Util.error(err.message);

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -5,3 +5,4 @@ export * from "./Schematics";
 export * from "./App";
 export * from "./FileSystem";
 export * from "./Container";
+export * from "./Typings";

--- a/packages/igx-templates/package-resolve.spec.ts
+++ b/packages/igx-templates/package-resolve.spec.ts
@@ -17,6 +17,9 @@ class MockFileSystem implements IFileSystem {
 	public directoryExists(dirPath: string): boolean {
 		throw new Error("Method not implemented.");
 	}
+	public removeDir(dirPath: string, force: boolean): boolean {
+		throw new Error("Method not implemented.");
+	}
 	public glob(dirPath: string, pattern: string): string[] {
 		throw new Error("Method not implemented.");
 	}

--- a/spec/acceptance/help-spec.ts
+++ b/spec/acceptance/help-spec.ts
@@ -46,6 +46,7 @@ describe("Help command", () => {
 		test                   executes project tests
 		list                   list all templates                           [aliases: l]
 		upgrade-packages        upgrades Ignite UI Packages
+		update [package] [version] updates a package or lists packages for update
 	  Options:
 		--version, -v  Show current Ignite UI CLI version                    [boolean]
 		--help, -h     Show help                                             [boolean]`.replace(/\s/g, "");

--- a/spec/acceptance/update-spec.ts
+++ b/spec/acceptance/update-spec.ts
@@ -1,0 +1,116 @@
+// tslint:disable:object-literal-sort-keys
+import { GoogleAnalytics, GoogleAnalyticsParameters, Package, ProjectConfig, Util } from "@igniteui/cli-core";
+import * as fs from "fs-extra";
+import { parse } from "path";
+import * as cli from "../../packages/cli/lib/cli";
+
+describe("Unit - Update command", () => {
+	let testFolder = parse(__filename).name;
+	// tslint:disable:no-console
+	beforeEach(() => {
+		spyOn(console, "log");
+		spyOn(console, "error");
+		spyOn(GoogleAnalytics, "post");
+
+		// test folder, w/ existing check:
+		while (fs.existsSync(`./output/${testFolder}`)) {
+			testFolder += 1;
+		}
+		fs.mkdirSync(`./output/${testFolder}`);
+		process.chdir(`./output/${testFolder}`);
+	});
+
+	afterEach(() => {
+		// clean test folder:
+		process.chdir("../../");
+		fs.rmdirSync(`./output/${testFolder}`);
+	});
+
+	it("Should not work without a project", async done => {
+		await cli.run(["update"]);
+
+		expect(console.error).toHaveBeenCalledWith(
+			jasmine.stringMatching(/Update command is supported only on existing project created with igniteui-cli\s*/)
+		);
+		expect(console.log).toHaveBeenCalledTimes(0);
+		let expectedPrams: GoogleAnalyticsParameters = {
+			t: "screenview",
+			cd: "Update"
+		};
+		expect(GoogleAnalytics.post).toHaveBeenCalledWith(expectedPrams);
+
+		expectedPrams = {
+			t: "screenview",
+			cd: "error: Update command is supported only on existing project created with igniteui-cli"
+		};
+		expect(GoogleAnalytics.post).toHaveBeenCalledWith(expectedPrams);
+		expect(GoogleAnalytics.post).toHaveBeenCalledTimes(2);
+		done();
+	});
+
+	it("Should not work in a dirty working tree", async done => {
+		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({ project: { framework: "angular" } }));
+		spyOn(Util, "checkWorkingTreeIsClean").and.returnValue(false);
+		await cli.run(["update"]);
+
+		expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/Update command can only be executed on a clean Git state\s*/));
+		fs.unlinkSync(ProjectConfig.configFile);
+		done();
+	});
+
+	it("Should not work with wrong framework", async done => {
+		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({ project: { framework: "some-framework" } }));
+		spyOn(Util, "checkWorkingTreeIsClean").and.returnValue(true);
+		await cli.run(["update"]);
+
+		expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/Framework not supported\s*/));
+		fs.unlinkSync(ProjectConfig.configFile);
+		done();
+	});
+
+	it("should list all packages for update if called without args", async done => {
+		spyOn(Util, "checkWorkingTreeIsClean").and.returnValue(true);
+		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({
+			project: {
+				framework: "angular",
+				sourceRoot: "./"
+			}
+		}));
+		fs.writeFileSync("package.json", JSON.stringify({
+			name: "some-package",
+			version: "12.3.45",
+			dependencies: {},
+			devDependencies: {},
+			igCli: {
+				migrations: "some/path"
+			}
+		}));
+
+		const packages: Package[] = [{
+			name: "some-package",
+			path: "test/test",
+			version: "12.3.45",
+			versionAfterUpdate: "12.12.12",
+			package: {}
+		}];
+		spyOn(Util, "lookUpPackagesForUpdate").and.returnValue(packages);
+		spyOn(Util, "log");
+		await cli.run(["update"]);
+
+		expect(Util.log).toHaveBeenCalledTimes(5);
+
+		fs.unlinkSync("package.json");
+		fs.unlinkSync(ProjectConfig.configFile);
+		done();
+	});
+
+	it("should successfully update a package to provided version", async done => {
+		// TODO
+		done();
+	});
+
+	it("should successfully call migrations up to a given version", async done => {
+		// TODO
+		done();
+	});
+});

--- a/spec/jasmine-runner.ts
+++ b/spec/jasmine-runner.ts
@@ -1,4 +1,4 @@
-import Jasmine = require("jasmine");
+import { default as Jasmine  } from "jasmine";
 import { DisplayProcessor, SpecReporter } from "jasmine-spec-reporter";
 
 class CustomProcessor extends DisplayProcessor {

--- a/spec/unit/ts-transform/TypeScriptUtils-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptUtils-spec.ts
@@ -60,7 +60,7 @@ describe("Unit - TypeScriptUtils", () => {
 				const source: ts.SourceFile = {} as any;
 				printerSpy.and.returnValue(printer);
 
-				const result = TypeScriptUtils.saveFile(`test/file${key}.ts`, source);
+				TypeScriptUtils.saveFile(`test/file${key}.ts`, source as any);
 				expect(printer.printFile).toHaveBeenCalledWith(source);
 				expect(fs.writeFileSync).toHaveBeenCalledWith(`test/file${key}.ts`, expectedText.join(newLines[key]));
 			}
@@ -73,15 +73,15 @@ describe("Unit - TypeScriptUtils", () => {
 		it("Creates correct identifier or method call", async done => {
 			const printer = ts.createPrinter();
 			const identifier = TypeScriptUtils.createIdentifier("Test");
-			expect(identifier.kind).toBe(ts.SyntaxKind.Identifier);
-			const identifierText = printer.printNode(ts.EmitHint.Unspecified, identifier, null);
+			expect(identifier.kind as ts.SyntaxKind.Identifier).toBe(ts.SyntaxKind.Identifier);
+			const identifierText = printer.printNode(ts.EmitHint.Unspecified, (identifier as unknown) as ts.Node, null);
 			expect(identifierText).toBe("Test");
 
 			const identifierCall = TypeScriptUtils.createIdentifier("Test", "method");
-			expect(identifierCall.kind).toBe(ts.SyntaxKind.CallExpression);
+			expect(identifierCall.kind as ts.SyntaxKind).toBe(ts.SyntaxKind.CallExpression);
 			const identifierCallText = printer.printNode(
 				ts.EmitHint.Unspecified,
-				identifierCall,
+				(identifierCall as unknown) as ts.Node,
 				ts.createSourceFile("", "", ts.ScriptTarget.Latest)
 			);
 			expect(identifierCallText).toBe("Test.method()");
@@ -91,15 +91,15 @@ describe("Unit - TypeScriptUtils", () => {
 		it("Creates correct import node", async done => {
 			const printer = ts.createPrinter();
 			const nameImport = TypeScriptUtils.createIdentifierImport(["Name"], "package");
-			expect(nameImport.kind).toBe(ts.SyntaxKind.ImportDeclaration);
-			expect((nameImport.moduleSpecifier as ts.StringLiteral).text).toBe("package");
+			expect(nameImport.kind as ts.SyntaxKind).toBe(ts.SyntaxKind.ImportDeclaration);
+			expect(((nameImport.moduleSpecifier as unknown) as ts.StringLiteral).text).toBe("package");
 			expect(nameImport.importClause.namedBindings).toBeDefined();
-			expect(printer.printNode(ts.EmitHint.Unspecified, nameImport, null)).toBe(`import { Name } from "package";`);
+			expect(printer.printNode(ts.EmitHint.Unspecified, (nameImport as unknown) as ts.Node, null)).toBe(`import { Name } from "package";`);
 
 			const namesImport = TypeScriptUtils.createIdentifierImport(["Test1", "Test2"], "@namespace/package");
-			expect((namesImport.moduleSpecifier as ts.StringLiteral).text).toBe("@namespace/package");
+			expect(((namesImport.moduleSpecifier as unknown) as ts.StringLiteral).text).toBe("@namespace/package");
 			expect(namesImport.importClause.namedBindings).toBeDefined();
-			const namesImportText = printer.printNode(ts.EmitHint.Unspecified, namesImport, null);
+			const namesImportText = printer.printNode(ts.EmitHint.Unspecified, (namesImport as unknown) as ts.Node, null);
 			expect(namesImportText).toBe(`import { Test1, Test2 } from "@namespace/package";`);
 			done();
 		});
@@ -109,7 +109,7 @@ describe("Unit - TypeScriptUtils", () => {
 		const classSource = ts.createSourceFile("",
 			`export class TestClass {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(classSource.getChildren())).toBe("TestClass");
+		expect(TypeScriptUtils.getClassName(classSource.getChildren() as any)).toBe("TestClass");
 
 		const classDecoratorSource = ts.createSourceFile("",
 			`@Component({
@@ -117,13 +117,13 @@ describe("Unit - TypeScriptUtils", () => {
 			})
 			export class TestDecoratorClass {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(classDecoratorSource.getChildren())).toBe("TestDecoratorClass");
+		expect(TypeScriptUtils.getClassName(classDecoratorSource.getChildren() as any)).toBe("TestDecoratorClass");
 
 		const multipleClassSource = ts.createSourceFile("",
 			`export class TestDecoratorClass1 {}
 			export class TestDecoratorClass2 {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(multipleClassSource.getChildren())).toBe("TestDecoratorClass1");
+		expect(TypeScriptUtils.getClassName(multipleClassSource.getChildren() as any)).toBe("TestDecoratorClass1");
 
 		const noExportClassSource = ts.createSourceFile("",
 			`function name() {
@@ -131,7 +131,7 @@ describe("Unit - TypeScriptUtils", () => {
 			}
 			export class TestDecoratorClass2 {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(noExportClassSource.getChildren())).toBe("TestDecoratorClass2");
+		expect(TypeScriptUtils.getClassName(noExportClassSource.getChildren() as any)).toBe("TestDecoratorClass2");
 		done();
 	});
 });

--- a/spec/unit/update-spec.ts
+++ b/spec/unit/update-spec.ts
@@ -1,0 +1,3 @@
+describe("Update command", () => {
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
 	"compilerOptions": {
 		"baseUrl": ".",
-		"target": "es6",
-		"module": "commonjs",
+		"target": "ES6",
+		"module": "CommonJS",
+		"esModuleInterop": true,
+		"moduleResolution": "Node16",
 		"sourceMap": true,
 		"paths": {
 			"@igniteui/cli-core": [

--- a/tslint.json
+++ b/tslint.json
@@ -50,10 +50,7 @@
 		"prefer-object-spread": false,
 		"prefer-conditional-expression": false,
 		"object-literal-sort-keys": [
-			true,
-			"ignore-case",
-			"match-declaration-order",
-			"shorthand-first"
+			false
 		]
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,7 +2951,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz"
   integrity "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs= sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig=="
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   dependencies:
@@ -3690,6 +3690,11 @@ istanbul-reports@^2.1.1:
   dependencies:
     html-escaper "^2.0.0"
 
+jasmine-core@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.4.0.tgz#848fe45c1839cacaf1f2429d400d1d4f85d2856a"
+  integrity sha512-+l482uImx5BVd6brJYlaHe2UwfKoZBqQfNp20ZmdNfsjGFTemGfqHLsXjKEW23w9R/m8WYeFc9JmIgjj6dUtAA==
+
 jasmine-core@~3.5.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz"
@@ -3712,6 +3717,14 @@ jasmine@3.5.0:
   dependencies:
     glob "^7.1.4"
     jasmine-core "~3.5.0"
+
+jasmine@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-4.4.0.tgz#e3e359723d9679993b70de3e0441517c154b9647"
+  integrity sha512-xrbOyYkkCvgduNw7CKktDtNb+BwwBv/zvQeHpTkbxqQ37AJL5V4sY3jHoMIJPP/hTc3QxLVwOyxc87AqA+kw5g==
+  dependencies:
+    glob "^7.1.6"
+    jasmine-core "^4.4.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -6305,6 +6318,11 @@ typescript@^3.5.3:
 typescript@^4.6.2, typescript@~4.7.2:
   version "4.7.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz"
+
+typescript@^4.9.0-dev.20220914:
+  version "4.9.0-dev.20220914"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.0-dev.20220914.tgz#16b3253d784cb0739dba362cc55adeebd9c8fd50"
+  integrity sha512-U1GcTQISGDyNlwr/OUTQVKFGMjL5eYrzT4nTptRn6lcaiRwO0+zmdHD3FMf6ZdiV5wZMMU706GH08EgiBufIqw==
 
 typescript@~4.5.2:
   version "4.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,7 +1005,7 @@
   version "1.2.2"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^8.0.31", "@types/node@^8.10.0":
+"@types/node@*", "@types/node@>= 8", "@types/node@^8.0.31":
   version "8.10.66"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz"
 
@@ -1016,6 +1016,11 @@
 "@types/node@^12.11.1":
   version "12.20.52"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz"
+
+"@types/node@^14.18.27":
+  version "14.18.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.28.tgz#ddb82da2fff476a8e827e8773c84c19d9c235278"
+  integrity sha512-CK2fnrQlIgKlCV3N2kM+Gznb5USlwA1KFX3rJVHmgVk6NJxFPuQ86pAcvKnu37IA4BGlSRz7sEE1lHL1aLZ/eQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1375,7 +1380,7 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
 
-axios@0.21.4:
+axios@0.21.4, axios@~0.21.4:
   version "0.21.4"
   resolved "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"
   dependencies:
@@ -3386,6 +3391,13 @@ is-ci@^2.0.0:
 is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz"
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -5414,6 +5426,15 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.6.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@~1.22.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resp-modifier@6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz"
@@ -5493,7 +5514,7 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1, semver@~5.7.1:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
 
@@ -6251,7 +6272,7 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz"
 
-type-fest@^0.3.0:
+type-fest@^0.3.0, type-fest@~0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz"
 


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-cli/issues/1056

Depends on https://github.com/IgniteUI/igniteui-cli/pull/1059, which updates the CLI to use [TypeScript modules](https://www.typescriptlang.org/docs/handbook/modules.html). We are trying to use dynamic imports in `TS` to get to logic that's been delegated to whoever is implementing a given migration. These changes cause build errors and a bunch of tests to go haywire which is expected as we are essentially changing the way we export/import modules across the whole of the CLI.