### PR TITLE
Update cli for ts modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"fs-extra": "^3.0.1",
 		"glob": "^7.1.2",
 		"inquirer": "^6.4.1",
-		"jasmine": "3.5.0",
+		"jasmine": "^4.4.0",
 		"jasmine-spec-reporter": "^4.2.1",
 		"lerna": "^3.16.4",
 		"lerna-changelog": "^0.8.2",
@@ -79,7 +79,7 @@
 		"source-map-support": "^0.5.4",
 		"ts-node": "^6.2.0",
 		"tslint": "^5.11.0",
-		"typescript": "~4.5.2",
+		"typescript": "^4.9.0-dev.20220914",
 		"typescript-json-schema": "^0.42.0"
 	},
 	"workspaces": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@types/fs-extra": "^3.0.3",
 		"@types/inquirer": "0.0.35",
 		"@types/jasmine": "3.3.9",
-		"@types/node": "^8.10.0",
+		"@types/node": "^14.18.27",
 		"browser-sync": "^2.26.3",
 		"coveralls": "^3.0.0",
 		"fs-extra": "^3.0.1",

--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -1,5 +1,5 @@
 import { App, GoogleAnalytics, Util } from "@igniteui/cli-core";
-import * as yargs from "yargs";
+import { default as yargs } from "yargs";
 import { default as add } from "./commands/add";
 import { default as build } from "./commands/build";
 import { default as config } from "./commands/config";

--- a/packages/cli/lib/templates/AngularTemplate.ts
+++ b/packages/cli/lib/templates/AngularTemplate.ts
@@ -104,7 +104,8 @@ export class AngularTemplate implements Template {
 
 	protected ensureSourceFiles(projectPath: string) {
 		// tslint:disable-next-line:no-submodule-imports
-		const components = require("@igniteui/cli-core/packages/components");
+		const module = require("@igniteui/cli-core/packages/components");
+		const components = module.dv ? module : module.default;
 		const config = ProjectConfig.getConfig();
 		const files: string[] = config.project.sourceFiles;
 		const dvDependencies = this.dependencies.filter(x => components.dv.indexOf(x) !== -1);

--- a/packages/cli/lib/templates/jQueryTemplate.ts
+++ b/packages/cli/lib/templates/jQueryTemplate.ts
@@ -34,7 +34,7 @@ export class jQueryTemplate implements Template {
 		return [path.join(this.rootPath, "files")];
 	}
 
-	public generateConfig(name: string, options: {}): {[key: string]: any} {
+	public generateConfig(name: string, options: {}): { [key: string]: any } {
 		let config = {};
 		if (options["extraConfig"]) {
 			config = options["extraConfig"];
@@ -91,7 +91,7 @@ export class jQueryTemplate implements Template {
 	}
 	protected getScriptTags(): string {
 		// tslint:disable-next-line:no-submodule-imports
-		const config = require("@igniteui/cli-core/packages/components");
+		const config = require("@igniteui/cli-core/packages/components").default;
 		let builder = "";
 		builder += this.getJqueryDependenciesScriptTag();
 		builder += "\n\n";

--- a/packages/cli/migrations/update-2/index.spec.ts
+++ b/packages/cli/migrations/update-2/index.spec.ts
@@ -13,7 +13,7 @@ describe("Update 2.0.0", () => {
 		appTree = new UnitTestTree(new EmptyTree());
 	});
 
-	it("should update router event rxjs subscription", async done => {
+	it("should update router event rxjs subscription", async () => {
 		appTree.create(
 			"/src/app/app.component.ts",
 `import { Component, OnInit, ViewChild } from '@angular/core';
@@ -78,7 +78,6 @@ export class AppComponent implements OnInit {
 }
 `
 			);
-		done();
 	});
 
 });

--- a/packages/cli/migrations/update-3/index.spec.ts
+++ b/packages/cli/migrations/update-3/index.spec.ts
@@ -13,7 +13,7 @@ describe("Update 3.0.0", () => {
 		appTree = new UnitTestTree(new EmptyTree());
 	});
 
-	it("should add igx-typography class to body if needed", async done => {
+	it("should add igx-typography class to body if needed", async () => {
 		const indexFile = "/src/index.html";
 		appTree.create(indexFile,
 `<body>
@@ -39,10 +39,9 @@ describe("Update 3.0.0", () => {
 		appTree.overwrite(indexFile, `<body class="test igx-typography">`);
 		await schematicRunner.runSchematicAsync("migration-02", {}, appTree).toPromise();
 		expect(appTree.readContent(indexFile)).toEqual(`<body class="test igx-typography">`);
-		done();
 	});
 
-	it("should add additional header styles to home css", async done => {
+	it("should add additional header styles to home css", async () => {
 		const cssFile = "/src/app/home/home.component.css";
 		appTree.create(cssFile,
 `body {
@@ -70,10 +69,9 @@ h3 {
 }
 `
 			);
-		done();
 	});
 
-	it("should remove forRoot() from IgxGridModule", async done => {
+	it("should remove forRoot() from IgxGridModule", async () => {
 		const indexFile = "/src/app/app.module.ts";
 		appTree.create(indexFile,
 `@NgModule({
@@ -94,10 +92,9 @@ h3 {
   ]
 })`
 			);
-		done();
 	});
 
-	it("should update config", async done => {
+	it("should update config", async () => {
 		const indexFile = "ignite-ui-cli.json";
 		appTree.create(indexFile,
 `{
@@ -125,6 +122,5 @@ h3 {
 }
 `
 			);
-		done();
 	});
 });

--- a/packages/cli/migrations/update-3_2/index.spec.ts
+++ b/packages/cli/migrations/update-3_2/index.spec.ts
@@ -23,7 +23,7 @@ describe("Update 3.2.0", () => {
 		appTree.create("/angular.json", JSON.stringify(configJson));
 	});
 
-	it("should update CustomDateSummary summaryResult assignment", async done => {
+	it("should update CustomDateSummary summaryResult assignment", async () => {
 		const summaryFile = "/src/app/grid-summaries/grid-summaries.component.ts";
 		appTree.create(summaryFile,
 `class CustomDateSummary extends IgxDateSummaryOperand {
@@ -70,6 +70,5 @@ describe("Update 3.2.0", () => {
    }
  }`
 			);
-		done();
 	});
 });

--- a/packages/cli/migrations/update-4_2_3/index.spec.ts
+++ b/packages/cli/migrations/update-4_2_3/index.spec.ts
@@ -23,7 +23,7 @@ describe("Update 4.2.3", () => {
 		appTree.create("/angular.json", JSON.stringify(configJson));
 	});
 
-	it("should add Awesome Grid extra paginator style", async done => {
+	it("should add Awesome Grid extra paginator style", async () => {
 		const stylesFile = "/src/app/awesome-grid/awesome-grid.component.scss";
 		appTree.create(stylesFile,
 `@use 'igniteui-angular/theming' as *;
@@ -69,6 +69,5 @@ describe("Update 4.2.3", () => {
 }
 `.replace(/\r\n/g, "\n")
 			);
-		done();
 	});
 });

--- a/packages/cli/migrations/update-5_0_0/index.spec.ts
+++ b/packages/cli/migrations/update-5_0_0/index.spec.ts
@@ -30,7 +30,7 @@ indent_size = 2
 `);
 	});
 
-	it("should add HammerModule", async done => {
+	it("should add HammerModule", async () => {
 		const indexFile = "/src/app/app.module.ts";
 		appTree.create(indexFile,
 `import { BrowserModule } from '@angular/platform-browser';
@@ -60,6 +60,5 @@ export class AppModule {
 }
 `.replace(/\r\n/g, "\n")
 			);
-		done();
 	});
 });

--- a/packages/cli/migrations/update-5_0_3/index.spec.ts
+++ b/packages/cli/migrations/update-5_0_3/index.spec.ts
@@ -24,7 +24,7 @@ describe("Update 5.0.0", () => {
 		appTree.create("/angular.json", JSON.stringify(configJson));
 	});
 
-	it("should update error handler service if found", async done => {
+	it("should update error handler service if found", async () => {
 		const errorService = "src/app/error-routing/error/global-error-handler.service.ts";
 		appTree.create(errorService,
 `import { ErrorHandler, Injectable, isDevMode } from '@angular/core';
@@ -55,6 +55,5 @@ export class GlobalErrorHandlerService implements ErrorHandler {
 }
 `.replace(/\r\n/g, "\n")
 			);
-		done();
 	});
 });

--- a/packages/cli/templates/angular/ig-ts/index.ts
+++ b/packages/cli/templates/angular/ig-ts/index.ts
@@ -1,6 +1,6 @@
 import { BaseProjectLibrary } from "@igniteui/cli-core";
 
-class AngularFramework extends BaseProjectLibrary {
+class AngularProjectLibrary extends BaseProjectLibrary {
 	constructor() {
 		super(__dirname);
 		this.name = "Ignite UI Angular Wrappers";
@@ -14,4 +14,5 @@ class AngularFramework extends BaseProjectLibrary {
 		}
 	}
 }
-module.exports = new AngularFramework();
+
+export const factory = () => new AngularProjectLibrary();

--- a/packages/cli/templates/angular/index.ts
+++ b/packages/cli/templates/angular/index.ts
@@ -13,4 +13,5 @@ class AngularFramework implements Framework {
 		this.projectLibraries.push(require("./ig-ts") as ProjectLibrary);
 	}
 }
-export = new AngularFramework() as Framework;
+
+export const factory = () => new AngularFramework() as Framework;

--- a/packages/cli/templates/angular/index.ts
+++ b/packages/cli/templates/angular/index.ts
@@ -9,8 +9,8 @@ class AngularFramework implements Framework {
 		this.id = "angular";
 		this.name = "Angular";
 		this.projectLibraries = [];
-		this.projectLibraries.push(require("@igniteui/angular-templates").default as ProjectLibrary);
-		this.projectLibraries.push(require("./ig-ts") as ProjectLibrary);
+		this.projectLibraries.push(require("@igniteui/angular-templates").default.factory() as ProjectLibrary);
+		this.projectLibraries.push(require("./ig-ts").factory() as ProjectLibrary);
 	}
 }
 

--- a/packages/cli/templates/jquery/index.ts
+++ b/packages/cli/templates/jquery/index.ts
@@ -13,4 +13,5 @@ class jQueryFramework implements Framework {
 		this.projectLibraries.push(require("./js") as ProjectLibrary);
 	}
 }
-export = new jQueryFramework() as Framework;
+
+export const factory = () => new jQueryFramework() as Framework;

--- a/packages/cli/templates/react/index.ts
+++ b/packages/cli/templates/react/index.ts
@@ -13,4 +13,5 @@ class ReactFramework implements Framework {
 		this.projectLibraries.push(require("./igr-es6") as ProjectLibrary);
 	}
 }
-export = new ReactFramework() as Framework;
+
+export const factory = () => new ReactFramework() as Framework;

--- a/packages/cli/templates/webcomponents/index.ts
+++ b/packages/cli/templates/webcomponents/index.ts
@@ -12,4 +12,5 @@ class WebComponentsFramework implements Framework {
 		this.projectLibraries.push(require("./igc-ts") as ProjectLibrary);
 	}
 }
-export = new WebComponentsFramework() as Framework;
+
+export const factory = () => new WebComponentsFramework() as Framework;

--- a/packages/core/packages/PackageManager.ts
+++ b/packages/core/packages/PackageManager.ts
@@ -4,7 +4,7 @@ import { TemplateManager } from "../../cli/lib/TemplateManager";
 import { Config, FS_TOKEN, IFileSystem, ProjectTemplate } from "../types";
 import { App, ProjectConfig, Util } from "../util";
 
-import componentsConfig = require("./components");
+import componentsConfig from "./components";
 
 export class PackageManager {
 	private static ossPackage: string = "ignite-ui";

--- a/packages/core/packages/components.ts
+++ b/packages/core/packages/components.ts
@@ -1,4 +1,4 @@
-export = {
+export default {
 	dv: [
 		"igDataChart",
 		"igPieChart",

--- a/packages/core/templates/BaseTemplateManager.ts
+++ b/packages/core/templates/BaseTemplateManager.ts
@@ -12,8 +12,9 @@ export abstract class BaseTemplateManager {
 		const frameworks = Util.getDirectoryNames(this.templatesAbsPath)
 			.filter(x => x !== this._quickstartTemplatesPath);
 		// load and initialize templates
-		for (const framework of frameworks) {
-			this.frameworks.push(require(path.join(this.templatesAbsPath, framework)) as Framework);
+		for (const frameworkName of frameworks) {
+			const framework = require(path.join(this.templatesAbsPath, frameworkName));
+			this.frameworks.push(framework.factory());
 		}
 
 		// load external templates

--- a/packages/core/types/FileSystem.ts
+++ b/packages/core/types/FileSystem.ts
@@ -1,6 +1,6 @@
 export interface IFileSystem {
 	fileExists(filePath: string): boolean;
-	readFile(filePath: string, encoding?: string): string;
+	readFile(filePath: string, encoding?: BufferEncoding): string;
 	writeFile(filePath: string, text: string): void;
 	directoryExists(dirPath: string): boolean;
 

--- a/packages/core/util/FileSystem.ts
+++ b/packages/core/util/FileSystem.ts
@@ -12,9 +12,9 @@ export class FsFileSystem implements IFileSystem {
 			return false;
 		}
 	}
-	public readFile(filePath: string, encoding?: string): string {
+	public readFile(filePath: string, encoding?: BufferEncoding): string {
 		if (encoding) {
-			return fs.readFileSync(filePath, encoding);
+			return fs.readFileSync(filePath, { encoding });
 		}
 		return fs.readFileSync(filePath).toString();
 	}

--- a/packages/core/util/GoogleAnalytics.ts
+++ b/packages/core/util/GoogleAnalytics.ts
@@ -8,6 +8,7 @@ import { ProjectConfig } from "./ProjectConfig";
 import { Util } from "./Util";
 
 class GoogleAnalytics {
+	public static https;
 	protected static userDataFolder: string = process.env.APPDATA ||
 		(process.platform === "darwin" ? "/Users/Shared" : process.env.HOME + "/.npm/");
 	protected static appFolder = "igniteui-cli";
@@ -58,7 +59,7 @@ class GoogleAnalytics {
 		const queryString = qs.stringify(parameters as {});
 		const fullPath = "/collect?" + queryString;
 		const options = { host: "www.google-analytics.com", path: fullPath, method: "POST" };
-		const https = require("https");
+		const https = this.https || require("https");
 		const req = https.request(options);
 		req.on("error", e => {
 			// TODO: save all the logs and send them later

--- a/packages/core/util/ProjectConfig.ts
+++ b/packages/core/util/ProjectConfig.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as os from "os";
+import * as _os from "os";
 import * as path from "path";
 import { Config } from "../types/Config";
 import { FS_TOKEN, IFileSystem } from "../types/FileSystem";
@@ -10,12 +10,13 @@ export class ProjectConfig {
 
 	public static configFile: string = "ignite-ui-cli.json";
 	public static readonly defaults: Config = require("../config/defaults.json");
+	public static os = _os;
 
 	private static schemaPath = "../config/Config.schema.json";
 
 	/** Returns true if there's a CLI config file in the current working directory */
 	public static hasLocalConfig(): boolean {
-		if (os.homedir() === process.cwd()) {
+		if (this.os.homedir() === process.cwd()) {
 			return false;
 		}
 		return App.container.get<IFileSystem>(FS_TOKEN).fileExists(this.configFile);
@@ -45,7 +46,7 @@ export class ProjectConfig {
 	 */
 	public static setConfig(config: Config, global: boolean = false) {
 		if (global) {
-			const filePath = path.join(os.homedir(), this.configFile);
+			const filePath = path.join(this.os.homedir(), this.configFile);
 			fs.writeFileSync(filePath, JSON.stringify(config, null, 4) + "\n");
 		} else {
 			App.container.get<IFileSystem>(FS_TOKEN).writeFile(this.configFile, JSON.stringify(config, null, 4) + "\n");
@@ -70,7 +71,7 @@ export class ProjectConfig {
 
 	/*** Get global configuration only */
 	public static globalConfig(): Config {
-		const globalConfigPath = path.join(os.homedir(), this.configFile);
+		const globalConfigPath = path.join(this.os.homedir(), this.configFile);
 		let globalConfig = {};
 
 		if (Util.fileExists(globalConfigPath)) {

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -340,7 +340,7 @@ export class Util {
 	 */
 	public static gitInit(parentRoot, projectName) {
 		try {
-			const options = { cwd: path.join(parentRoot, projectName), stdio: [process.stdin, "ignore", "ignore"] };
+			const options = { cwd: path.join(parentRoot, projectName), stdio: [process.stdin, "ignore", "ignore"] } as any;
 			Util.execSync("git init", options);
 			Util.execSync("git add .", options);
 			Util.execSync("git commit -m " + "\"Initial commit for project: " + projectName + "\"", options);

--- a/packages/igx-templates/igx-ts/index.ts
+++ b/packages/igx-templates/igx-ts/index.ts
@@ -17,4 +17,5 @@ class IgxProjectLibrary extends BaseProjectLibrary {
 		}
 	}
 }
-module.exports = new IgxProjectLibrary();
+
+export const factory = () => new IgxProjectLibrary();

--- a/packages/ng-schematics/src/start/index.ts
+++ b/packages/ng-schematics/src/start/index.ts
@@ -1,3 +1,4 @@
+// tslint:disable:object-literal-sort-keys
 import { Rule, SchematicContext, Tree } from "@angular-devkit/schematics";
 import { ScopedTree } from "@angular-devkit/schematics/src/tree/scoped";
 import { ProjectConfig, Util } from "@igniteui/cli-core";

--- a/packages/ng-schematics/src/upgrade-packages/index.spec.ts
+++ b/packages/ng-schematics/src/upgrade-packages/index.spec.ts
@@ -18,7 +18,7 @@ describe("Schematics upgrade-packages", () => {
 		appTree = new UnitTestTree(new EmptyTree());
 	});
 
-	it("calls project template upgradeIgniteUIPackages and schedules install accordingly", async done => {
+	it("calls project template upgradeIgniteUIPackages and schedules install accordingly", async () => {
 		const runner = new SchematicTestRunner("schematics", collectionPath);
 
 		const mockConfig = {
@@ -68,7 +68,5 @@ describe("Schematics upgrade-packages", () => {
 		expect(upgradeSpy).toHaveBeenCalledTimes(3);
 		const installTaskOptions = new NodePackageInstallTask().toConfiguration();
 		expect(runner.tasks).toContain(jasmine.objectContaining(installTaskOptions));
-
-		done();
 	});
 });

--- a/spec/acceptance/add-spec.ts
+++ b/spec/acceptance/add-spec.ts
@@ -25,10 +25,10 @@ describe("Add command", () => {
 	afterEach(() => {
 		// clean test folder:
 		process.chdir("../../");
-		fs.rmdirSync(`./output/${testFolder}`);
+		fs.rmSync(`./output/${testFolder}`, { recursive: true, force: true });
 	});
 
-	it("Should not work without a project", async done => {
+	it("Should not work without a project", async () => {
 		await cli.run(["add", "grid", "name"]);
 
 		expect(console.error).toHaveBeenCalledWith(
@@ -54,11 +54,9 @@ describe("Add command", () => {
 			jasmine.stringMatching(/Add command is supported only on existing project created with igniteui-cli\s*/)
 		);
 		expect(console.log).toHaveBeenCalledTimes(0);
-
-		done();
 	});
 
-	it("Should not work quickstart project", async done => {
+	it("Should not work quickstart project", async () => {
 		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({ project: { isShowcase: true } }));
 		await cli.run(["add", "grid", "name"]);
 
@@ -68,10 +66,9 @@ describe("Add command", () => {
 		expect(console.log).toHaveBeenCalledTimes(0);
 
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 
-	it("Should not work with wrong framework", async done => {
+	it("Should not work with wrong framework", async () => {
 		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({ project: { framework: "angular2" } }));
 		await cli.run(["add", "grid", "name"]);
 
@@ -79,10 +76,9 @@ describe("Add command", () => {
 		expect(console.log).toHaveBeenCalledTimes(0);
 
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 
-	it("Should not work with wrong template", async done => {
+	it("Should not work with wrong template", async () => {
 		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({ project: { framework: "jquery" } }));
 		await cli.run(["add", "wrong", "name"]);
 
@@ -92,10 +88,9 @@ describe("Add command", () => {
 		expect(console.log).toHaveBeenCalledTimes(0);
 
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 
-	it("Should correctly add jQuery template", async done => {
+	it("Should correctly add jQuery template", async () => {
 		// TODO: Mock out template manager and project register
 		spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
@@ -112,14 +107,13 @@ describe("Add command", () => {
 		expect(fs.existsSync("./test-view/index.html")).toBeTruthy();
 		fs.unlinkSync("./test-view/index.html");
 		fs.unlinkSync("./test-view/style.css");
-		fs.rmdirSync("./test-view");
+		fs.rmSync("./test-view", { recursive: true, force: true });
 
 		fs.unlinkSync("ignite-cli-views.js");
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 
-	it("Should not duplicate add jq Grid template", async done => {
+	it("Should not duplicate add jq Grid template", async () => {
 		spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
 		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({
@@ -162,13 +156,12 @@ describe("Add command", () => {
 
 		fs.unlinkSync("./test-view/index.html");
 		fs.unlinkSync("./test-view/style.css");
-		fs.rmdirSync("./test-view");
+		fs.rmSync("./test-view", { recursive: true, force: true });
 		fs.unlinkSync("ignite-cli-views.js");
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 
-	it("Should correctly add Angular template", async done => {
+	it("Should correctly add Angular template", async () => {
 		spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
 		fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({
@@ -242,11 +235,10 @@ describe("Add command", () => {
 		expect(GoogleAnalytics.post).toHaveBeenCalledWith(expectedPrams);
 		expect(GoogleAnalytics.post).toHaveBeenCalledTimes(2);
 
-		done();
 	});
 
 	for (const igxPackage of [NPM_PACKAGE, FEED_PACKAGE]) {
-		it(`Should correctly add Ignite UI for Angular template - ${igxPackage}`, async done => {
+		it(`Should correctly add Ignite UI for Angular template - ${igxPackage}`, async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
 			fs.writeFileSync("package.json", JSON.stringify({
@@ -319,12 +311,11 @@ export class AppModule {
 			fs.unlinkSync(ProjectConfig.configFile);
 			fs.unlinkSync("tslint.json");
 			fs.unlinkSync("package.json");
-			done();
 		});
 	}
 
 	it("Should correctly add Ignite UI for Angular template passing folders path and spaces/tabs in name arg"
-		, async done => {
+		, async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
 			fs.writeFileSync(ProjectConfig.configFile, JSON.stringify({
@@ -390,13 +381,12 @@ export class AppModule {
 			);
 
 			deleteAll("./src");
-			fs.rmdirSync("./src");
+			fs.rmSync("./src", { recursive: true, force: true });
 			fs.unlinkSync(ProjectConfig.configFile);
 			fs.unlinkSync("tslint.json");
-			done();
 		});
 
-	it("Should correctly add React template", async done => {
+	it("Should correctly add React template", async () => {
 		// TODO: Mock out template manager and project register
 		spyOn(ProjectConfig, "globalConfig").and.returnValue({});
 
@@ -416,6 +406,5 @@ export class AppModule {
 		fs.removeSync("./src");
 
 		fs.unlinkSync(ProjectConfig.configFile);
-		done();
 	});
 });

--- a/spec/acceptance/add-spec.ts
+++ b/spec/acceptance/add-spec.ts
@@ -6,6 +6,7 @@ import { parse } from "path";
 import * as cli from "../../packages/cli/lib/cli";
 import { deleteAll, resetSpy } from "../helpers/utils";
 
+// tslint:disable:object-literal-sort-keys
 describe("Add command", () => {
 	let testFolder = parse(__filename).name;
 	// tslint:disable:no-console

--- a/spec/acceptance/config-spec.ts
+++ b/spec/acceptance/config-spec.ts
@@ -1,4 +1,4 @@
-import { GoogleAnalytics, GoogleAnalyticsParameters } from "@igniteui/cli-core";
+import { GoogleAnalytics, GoogleAnalyticsParameters, ProjectConfig } from "@igniteui/cli-core";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -23,7 +23,7 @@ describe("Config command", () => {
 
 		// ~/.global/ homedir for global files:
 		fs.mkdirSync(`.global`);
-		spyOn(os, "homedir").and.returnValue(path.join(process.cwd(), ".global"));
+		ProjectConfig.os = { homedir: () => path.join(process.cwd(), ".global") } as any;
 	});
 
 	afterEach(() => {
@@ -33,7 +33,7 @@ describe("Config command", () => {
 		fs.rmdirSync(`./output/${testFolder}`);
 	});
 
-	it("Should not work without a project & global flag", async done => {
+	it("Should not work without a project & global flag", async () => {
 		await cli.run(["config", "get", "igPackageRegistry"]);
 		expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/No configuration file found in this folder!\s*/));
 
@@ -58,10 +58,9 @@ describe("Config command", () => {
 		await cli.run(["config", "add", "igPackageRegistry", "maybe"]);
 		expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/No configuration file found in this folder!\s*/));
 		expect(console.log).toHaveBeenCalledTimes(0);
-		done();
 	});
 
-	it("Should correctly read and update global values", async done => {
+	it("Should correctly read and update global values", async () => {
 		await cli.run(["config", "get", "igPackageRegistry", "--global"]);
 		expect(console.log).toHaveBeenCalledWith(
 			jasmine.stringMatching("https://packages.infragistics.com/npm/js-licensed/")
@@ -77,10 +76,9 @@ describe("Config command", () => {
 		expect(console.log).toHaveBeenCalledWith(jasmine.stringMatching("https://example.com"));
 
 		expect(console.error).toHaveBeenCalledTimes(0);
-		done();
 	});
 
-	it("Should correctly read and update local values", async done => {
+	it("Should correctly read and update local values", async () => {
 		fs.writeFileSync("ignite-ui-cli.json", JSON.stringify({ igPackageRegistry: "https://example.com" }));
 		await cli.run(["config", "get", "igPackageRegistry", "--global"]);
 		expect(console.log).toHaveBeenCalledWith(
@@ -102,6 +100,5 @@ describe("Config command", () => {
 		expect(console.log).toHaveBeenCalledWith(["path:C:\\Test"]);
 
 		expect(console.error).toHaveBeenCalledTimes(0);
-		done();
 	});
 });

--- a/spec/acceptance/generate-spec.ts
+++ b/spec/acceptance/generate-spec.ts
@@ -25,7 +25,7 @@ describe("Generate command", () => {
 
 		// ~/.global/ homedir for global files:
 		fs.mkdirSync(`.global`);
-		spyOn(os, "homedir").and.returnValue(path.join(process.cwd(), ".global"));
+		ProjectConfig.os = { homedir: () => path.join(process.cwd(), ".global") } as any;
 		const config = {};
 		ProjectConfig.setConfig(config as Config, true);
 	});
@@ -38,7 +38,7 @@ describe("Generate command", () => {
 		fs.rmdirSync(`./output/${testFolder}`);
 	});
 
-	it("Should correctly generate template with default values", async done => {
+	it("Should correctly generate template with default values", async () => {
 		await cli.run(["generate", "template"]);
 
 		expect(fs.existsSync(path.join(process.cwd(), ".global"))).toBeTruthy();
@@ -95,10 +95,9 @@ describe("Generate command", () => {
 		expect(GoogleAnalytics.post).toHaveBeenCalledWith(expectedParams);
 
 		expect(GoogleAnalytics.post).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Should correctly generate angular wrappers template", async done => {
+	it("Should correctly generate angular wrappers template", async () => {
 		await cli.run(["generate", "template", "angular-wrapper", "-f=angular", "-t=ig-ts"]);
 
 		expect(fs.existsSync(path.join(process.cwd(), ".global"))).toBeTruthy();
@@ -136,10 +135,9 @@ describe("Generate command", () => {
 		const pathDirectory = path.join(templateFolderPath, "files", "src", "app", "components", "__path__");
 		expect(fs.existsSync(pathDirectory)).toBeTruthy();
 		expect(fs.existsSync(path.join(pathDirectory, "__filePrefix__.component.ts"))).toBeTruthy();
-		done();
 	});
 
-	it("Should correctly generate angular template", async done => {
+	it("Should correctly generate angular template", async () => {
 		await cli.run(["generate", "template", "angular", "-f=angular", "-t=igx-ts"]);
 
 		expect(fs.existsSync(path.join(process.cwd(), ".global"))).toBeTruthy();
@@ -180,10 +178,9 @@ describe("Generate command", () => {
 		expect(fs.existsSync(path.join(pathDirectory, "__filePrefix__.component.html"))).toBeTruthy();
 		expect(fs.existsSync(path.join(pathDirectory, "__filePrefix__.component.spec.ts"))).toBeTruthy();
 		expect(fs.existsSync(path.join(pathDirectory, "__filePrefix__.component.ts"))).toBeTruthy();
-		done();
 	});
 
-	it("Should correctly generate react template", async done => {
+	it("Should correctly generate react template", async () => {
 		await cli.run(["generate", "template", "react", "-f=react", "-t=es6"]);
 
 		expect(fs.existsSync(path.join(process.cwd(), ".global"))).toBeTruthy();
@@ -220,6 +217,5 @@ describe("Generate command", () => {
 		const clientDirectory = path.join(templateFolderPath, "files", "src");
 		expect(fs.existsSync(clientDirectory)).toBeTruthy();
 		expect(fs.existsSync(path.join(clientDirectory, "components", "__path__", "index.js"))).toBeTruthy();
-		done();
 	});
 });

--- a/spec/acceptance/help-spec.ts
+++ b/spec/acceptance/help-spec.ts
@@ -5,7 +5,7 @@ import * as cli from "../../packages/cli/lib/cli";
 const execLocation = "packages/cli/bin/execute.js";
 describe("Help command", () => {
 
-	it("should list all available commands", async done => {
+	it("should list all available commands", async () => {
 		const exitError = Error("exit");
 		let thrownError;
 		const listeners = []/* process.listeners("exit") */;
@@ -54,10 +54,9 @@ describe("Help command", () => {
 		expect(consoleSpy).toHaveBeenCalledTimes(1);
 		const actualText: string = (consoleSpy.calls.mostRecent().args[0] + "").replace(/\s/g, "");
 		expect(originalHelpText).toEqual(actualText);
-		done();
 	});
 
-	it("should show help for individual commands", async done => {
+	it("should show help for individual commands", async () => {
 		const child = spawnSync("node", [execLocation, "new", "--help"], {
 			encoding: "utf-8"
 		});
@@ -78,10 +77,9 @@ describe("Help command", () => {
 		const actualNewText: string = (child.stdout.toString()).replace(/\s/g, "");
 
 		expect(actualNewText).toContain(replacedNewHelpText);
-		done();
 	});
 
-	it("should show help config sub-commands", async done => {
+	it("should show help config sub-commands", async () => {
 		const child = spawnSync("node", [execLocation, "config", "--help"], {
 			encoding: "utf-8"
 		});
@@ -99,9 +97,8 @@ describe("Help command", () => {
 		const actualNewText: string = (child.stdout.toString()).replace(/\s/g, "");
 
 		expect(actualNewText).toContain(replacedNewHelpText);
-		done();
 	});
-	it("should show help generate sub-commands", async done => {
+	it("should show help generate sub-commands", async () => {
 		const child = spawnSync("node", [execLocation, "generate", "--help"], {
 			encoding: "utf-8"
 		});
@@ -116,9 +113,8 @@ describe("Help command", () => {
 		const actualNewText: string = (child.stdout.toString()).replace(/\s/g, "");
 
 		expect(actualNewText).toContain(replacedNewHelpText);
-		done();
 	});
-	it("should show help generate template sub-commands", async done => {
+	it("should show help generate template sub-commands", async () => {
 		const child = spawnSync("node", [execLocation, "g", "t", "-h"], {
 			encoding: "utf-8"
 		});
@@ -138,9 +134,8 @@ describe("Help command", () => {
 		const actualNewText: string = (child.stdout.toString()).replace(/\s/g, "");
 
 		expect(actualNewText).toContain(replacedNewHelpText);
-		done();
 	});
-	it("should show help for list command", async done => {
+	it("should show help for list command", async () => {
 		const child = spawnSync("node", [execLocation, "list", "-h"], {
 			encoding: "utf-8"
 		});
@@ -156,6 +151,5 @@ describe("Help command", () => {
 		const actualNewText: string = (child.stdout.toString()).replace(/\s/g, "");
 
 		expect(actualNewText).toContain(replacedNewHelpText);
-		done();
 	});
 });

--- a/spec/acceptance/new-spec.ts
+++ b/spec/acceptance/new-spec.ts
@@ -22,7 +22,7 @@ describe("New command", () => {
 		process.chdir("../");
 	});
 
-	it("Creates jQuery project", async done => {
+	it("Creates jQuery project", async () => {
 
 		await cli.run(["new", "jQuery Proj", "--framework=jquery"]);
 
@@ -52,10 +52,9 @@ describe("New command", () => {
 		};
 		expect(GoogleAnalytics.post).toHaveBeenCalledWith(expectedPrams);
 		expect(GoogleAnalytics.post).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Creates React project", async done => {
+	it("Creates React project", async () => {
 		// process.argv = ["new", "reactProj", "--framework=react"];
 
 		await cli.run(["new", "React Proj", "--framework=react"]);
@@ -66,10 +65,9 @@ describe("New command", () => {
 		expect(JSON.parse(packageText).name).toEqual("react-proj");
 		expect(fs.existsSync("./React Proj/.gitignore")).toBeTruthy();
 		testFolder = "./React Proj";
-		done();
 	});
 
-	it("Creates Angular project", async done => {
+	it("Creates Angular project", async () => {
 		// process.argv = ["new", "reactProj", "--framework=react"];
 
 		await cli.run(["new", "ngx Proj", "--framework=angular", "--type=igx-ts"]);
@@ -80,10 +78,9 @@ describe("New command", () => {
 		expect(JSON.parse(packageText).name).toEqual("ngx-proj");
 		expect(fs.existsSync("./ngx Proj/.gitignore")).toBeTruthy();
 		testFolder = "./ngx Proj";
-		done();
 	});
 
-	it("Creates Ignite UI for Angular project", async done => {
+	it("Creates Ignite UI for Angular project", async () => {
 
 		await cli.run(["new", "Ignite UI for Angular", "--framework=angular", "--type=igx-ts", "--theme=default"]);
 
@@ -93,10 +90,9 @@ describe("New command", () => {
 		expect(JSON.parse(packageText).name).toEqual("ignite-ui-for-angular");
 		expect(fs.existsSync("./Ignite UI for Angular/.gitignore")).toBeTruthy();
 		testFolder = "./Ignite UI for Angular";
-		done();
 	});
 
-	it("Should not work on existing folders", async done => {
+	it("Should not work on existing folders", async () => {
 		fs.mkdirSync("testProj");
 		await cli.run(["new", "testProj"]);
 		expect(console.error).toHaveBeenCalledWith(jasmine.stringMatching(/Folder "testProj" already exists!/));
@@ -132,10 +128,9 @@ describe("New command", () => {
 			.toEqual("text", "Shouldn't overwrite existing project files!");
 
 		testFolder = "./testProj2";
-		done();
 	});
 
-	it("Git Status", async done => {
+	it("Git Status", async () => {
 		const projectName = "angularProj";
 		await cli.run(["new", projectName, "--framework=angular", "--type=igx-ts", "--theme=default"]);
 
@@ -145,10 +140,9 @@ describe("New command", () => {
 			.toMatch("Initial commit for project: " + projectName);
 		process.chdir("../");
 		testFolder = "./angularProj";
-		done();
 	});
 
-	it("Skip Git/Install with command option", async done => {
+	it("Skip Git/Install with command option", async () => {
 		spyOn(Util, "gitInit");
 		const projectName = "angularProj";
 		await cli.run(["new", projectName, "--framework=angular", "--type=igx-ts", "--skip-git", "--skip-install", "--theme=default"]);
@@ -157,10 +151,9 @@ describe("New command", () => {
 		expect(PackageManager.installPackages).not.toHaveBeenCalled();
 
 		testFolder = projectName;
-		done();
 	});
 
-	it("Creates project with single word name", async done => {
+	it("Creates project with single word name", async () => {
 		spyOn(Util, "gitInit");
 		const projectName = "a";
 		await cli.run(["new", projectName, "--framework=jquery"]);
@@ -170,6 +163,5 @@ describe("New command", () => {
 		expect(fs.existsSync("./a")).toBeTruthy();
 
 		testFolder = "./a";
-		done();
 	});
 });

--- a/spec/jasmine-runner.ts
+++ b/spec/jasmine-runner.ts
@@ -1,4 +1,4 @@
-import Jasmine = require("jasmine");
+import { default as Jasmine  } from "jasmine";
 import { DisplayProcessor, SpecReporter } from "jasmine-spec-reporter";
 
 class CustomProcessor extends DisplayProcessor {

--- a/spec/jasmine-runner.ts
+++ b/spec/jasmine-runner.ts
@@ -1,3 +1,4 @@
+import { App } from "@igniteui/cli-core";
 import { default as Jasmine  } from "jasmine";
 import { DisplayProcessor, SpecReporter } from "jasmine-spec-reporter";
 
@@ -25,4 +26,5 @@ jasmineInst.loadConfig({
 	]
 });
 
+App.initialize();
 jasmineInst.execute([], null);

--- a/spec/templates/angular-spec.ts
+++ b/spec/templates/angular-spec.ts
@@ -5,8 +5,8 @@ const templatesLocation = "../../packages/cli/templates/angular";
 describe("Angular templates", () => {
 
 	// tslint:disable-next-line:only-arrow-functions
-	it("Templates should have IDs", async function(done) {
-		const angularFramework = require(templatesLocation);
+	it("Templates should have IDs", async function() {
+		const angularFramework = require(templatesLocation).factory();
 		expect(angularFramework.projectLibraries[0]).toBeDefined();
 		expect(angularFramework.projectLibraries[1]).toBeDefined();
 
@@ -16,11 +16,10 @@ describe("Angular templates", () => {
 		for (const template of angularFramework.projectLibraries[1].templates) {
 			expect(template.id).toBeDefined("No ID: " + template.name + " type: " + template.projectType);
 		}
-		done();
 	});
 
-	it("Ig templates should have no internal collisions", async done => {
-		const angularFramework: Framework = require(templatesLocation);
+	it("Ig templates should have no internal collisions", async () => {
+		const angularFramework: Framework = require(templatesLocation).factory();
 		const projLibrary = angularFramework.projectLibraries.find(x => x.projectType === "ig-ts");
 		for (let i = 0; i < projLibrary.templates.length; i++) {
 			const element = projLibrary.templates[i];
@@ -32,11 +31,10 @@ describe("Angular templates", () => {
 				).toBeTruthy(`Template ${element.id} can overwrite ${target.id}`);
 			}
 		}
-		done();
 	});
 
-	it("Igx templates should have no internal collisions", async done => {
-		const angularFramework: Framework = require(templatesLocation);
+	it("Igx templates should have no internal collisions", async () => {
+		const angularFramework: Framework = require(templatesLocation).factory();
 		const projLibrary = angularFramework.projectLibraries.find(x => x.projectType === "igx-ts");
 		for (let i = 0; i < projLibrary.templates.length; i++) {
 			const element = projLibrary.templates[i];
@@ -48,6 +46,5 @@ describe("Angular templates", () => {
 				).toBeTruthy(`Template ${element.id} can overwrite ${target.id}`);
 			}
 		}
-		done();
 	});
 });

--- a/spec/templates/jquery-spec.ts
+++ b/spec/templates/jquery-spec.ts
@@ -4,14 +4,13 @@ const templatesLocation = "../../packages/cli/templates/jquery";
 describe("jQuery templates", () => {
 
 	// tslint:disable-next-line:only-arrow-functions
-	it("Templates should have IDs", async function(done) {
-		const jQueryFramework = require(templatesLocation);
+	it("Templates should have IDs", async function() {
+		const jQueryFramework = require(templatesLocation).factory();
 		expect(jQueryFramework.projectLibraries[0]).toBeDefined();
 
 		for (const template of jQueryFramework.projectLibraries[0].templates) {
 			expect(template.id).toBeDefined("No ID: " + template.name);
 		}
-		done();
 	});
 
 });

--- a/spec/templates/react-spec.ts
+++ b/spec/templates/react-spec.ts
@@ -4,18 +4,17 @@ const templatesLocation = "../../packages/cli/templates/react";
 describe("React templates", () => {
 
 	// tslint:disable-next-line:only-arrow-functions
-	it("Templates should have IDs", async function(done) {
-		const reactFramework = require(templatesLocation);
+	it("Templates should have IDs", async function() {
+		const reactFramework = require(templatesLocation).factory();
 		expect(reactFramework.projectLibraries[0]).toBeDefined();
 
 		for (const template of reactFramework.projectLibraries[0].templates) {
 			expect(template.id).toBeDefined("No ID: " + template.name + " type: " + template.projectType);
 		}
-		done();
 	});
 
-	it("Templates should have no internal collisions", async done => {
-		const reactFramework: Framework = require(templatesLocation);
+	it("Templates should have no internal collisions", async () => {
+		const reactFramework: Framework = require(templatesLocation).factory();
 		const projLibrary = reactFramework.projectLibraries.find(x => x.projectType === "es6");
 		for (let i = 0; i < projLibrary.templates.length; i++) {
 			const element = projLibrary.templates[i];
@@ -27,6 +26,5 @@ describe("React templates", () => {
 				).toBeTruthy(`Template ${element.id} can overwrite ${target.id}`);
 			}
 		}
-		done();
 	});
 });

--- a/spec/unit/BaseProjectLibrary-spec.ts
+++ b/spec/unit/BaseProjectLibrary-spec.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 describe("Unit - Base project library ", () => {
 
-	it("has correct projects.", async done => {
+	it("has correct projects.", async () => {
 		const mockProjects = ["angular", "jquery"];
 
 		spyOn(Util, "getDirectoryNames").and.returnValue(mockProjects);
@@ -12,10 +12,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.hasProject("angular")).toBe(true);
 		expect(library.projectIds).toEqual(mockProjects);
 		expect(Util.getDirectoryNames).toHaveBeenCalledWith(path.join("../test", "projects"));
-		done();
 	});
 
-	it("gets correct custom templates", async done => {
+	it("gets correct custom templates", async () => {
 
 		spyOn(Util, "getDirectoryNames").and.returnValues(["bar-chart", "combo"]);
 
@@ -36,10 +35,9 @@ describe("Unit - Base project library ", () => {
 
 		const library = new BaseProjectLibrary(__dirname);
 		expect(library.getCustomTemplateNames()).toEqual(["bar-chartName", "comboName"]);
-		done();
 	});
 
-	it("gets correct templates", async done => {
+	it("gets correct templates", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["bar-chart", "combo"], ["editors"]);
 
 		// spy on require(), https://coderwall.com/p/ck7w6g/spying-on-require-with-jasmine
@@ -73,10 +71,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.templates[2].name).toEqual("comboCustomName");
 		expect(library.components.length).toEqual(1);
 		expect(library.components[0].name).toEqual("editorsName");
-		done();
 	});
 
-	it("gets correct components", async done => {
+	it("gets correct components", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["bar-chart", "combo"]);
 
 		// spy on require(), https://coderwall.com/p/ck7w6g/spying-on-require-with-jasmine
@@ -97,10 +94,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.components.length).toEqual(2);
 		expect(library.components[0].group).toEqual("bar-chartGroup");
 		expect(library.components[1].name).toEqual("comboName");
-		done();
 	});
 
-	it("gets template by id and name.", async done => {
+	it("gets template by id and name.", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["grid", "chart"], ["awesome"]);
 
 		// spy on require(), https://coderwall.com/p/ck7w6g/spying-on-require-with-jasmine
@@ -142,10 +138,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.getTemplateByName("gridtemplatename")).toBeFalsy();
 		expect(library.getTemplateByName("awesomeCustomName")).toBeTruthy();
 		expect(library.getTemplateByName("chartTemplateName")).toBe(library.templates[1]);
-		done();
 	});
 
-	it("registers a template successfully.", async done => {
+	it("registers a template successfully.", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["grid", "chart"], ["awesome"]);
 
 		// spy on require(), https://coderwall.com/p/ck7w6g/spying-on-require-with-jasmine
@@ -186,10 +181,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.getTemplateByName("newName")).toBeTruthy();
 		expect(library.getComponentByName("newComponent")).toBeTruthy();
 		expect(library.templates.length).toEqual(3);
-		done();
 	});
 
-	it("gets [custom] component by name.", async done => {
+	it("gets [custom] component by name.", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["grid", "chart"], ["awesome"]);
 
 		// spy on require(), https://coderwall.com/p/ck7w6g/spying-on-require-with-jasmine
@@ -223,10 +217,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.getComponentByName("awesomeCustomName")).toBeFalsy();
 		expect(library.getCustomTemplateByName("awesomeCustomName")).toBeTruthy();
 		expect(library.getComponentByName("gridName")).toBe(library.components[0]);
-		done();
 	});
 
-	it("gets correct component groups", async done => {
+	it("gets correct component groups", async () => {
 		const hash = ["Grids & Lists Group", "Charts Group", "Maps Group", "Gauges Group", "Data Entry & Display Group"];
 		spyOn(Util, "getDirectoryNames").and.returnValues
 		(["Grids & Lists", "Charts", "Maps", "Gauges", "Data Entry & Display"]);
@@ -249,10 +242,9 @@ describe("Unit - Base project library ", () => {
 
 		expect(library.getComponentGroupNames()).toEqual([
 			"Grids & Lists Group", "Charts Group", "Maps Group", "Gauges Group", "Data Entry & Display Group"]);
-		done();
 	});
 
-	it("gets correct component names by group", async done => {
+	it("gets correct component names by group", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["chart", "combo", "grid"]);
 
 		spyOn(require("module"), "_load").and.callFake((modulePath: string) => {
@@ -290,10 +282,9 @@ describe("Unit - Base project library ", () => {
 
 		expect(library.getComponentsByGroup("commonGroup")).toEqual(expectedCommonGroup);
 		expect(library.getComponentsByGroup("gridGroup")).toEqual(expectedGridGroup);
-		done();
 	});
 
-	it("should sort component in a group based on priority", async done => {
+	it("should sort component in a group based on priority", async () => {
 		spyOnProperty(BaseProjectLibrary.prototype, "components").and.returnValue([
 			{ name: "Component1", group: "commonGroup", groupPriority: 1 },
 			{ name: "Component2", group: "commonGroup", groupPriority: 20 },
@@ -308,10 +299,9 @@ describe("Unit - Base project library ", () => {
 		expect(library.getComponentsByGroup("commonGroup").map(x => x.name)).toEqual(
 			["Component2", "Component3", "Component4", "Component1", "Component6", "Component7", "Component5"]
 		);
-		done();
 	});
 
-	it("gets correct project", async done => {
+	it("gets correct project", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["chart", "combo", "grid"]);
 
 		spyOn(require("module"), "_load").and.callFake((modulePath: string) => {
@@ -327,10 +317,9 @@ describe("Unit - Base project library ", () => {
 		const library = new BaseProjectLibrary(__dirname);
 
 		expect(library.getProject("grid")).toBeTruthy();
-		done();
 	});
 
-	it("has template.", async done => {
+	it("has template.", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(["chart", "combo", "grid"], ["customControl"]);
 
 		spyOn(require("module"), "_load").and.callFake((modulePath: string) => {
@@ -357,6 +346,5 @@ describe("Unit - Base project library ", () => {
 		expect(library.hasTemplate("grid")).toBeTruthy();
 		expect(library.hasTemplate("combo")).toBeTruthy();
 		expect(library.hasTemplate("customControlCustom")).toBeTruthy();
-		done();
 	});
 });

--- a/spec/unit/GoogleAnalytic-spec.ts
+++ b/spec/unit/GoogleAnalytic-spec.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as process from "process";
 import { deleteAll } from "../helpers/utils";
 
-fdescribe("Unit - Google Analytic", () => {
+describe("Unit - Google Analytic", () => {
 	let request;
 	let testFolder = path.parse(__filename).name;
 	let serviceSpy;
@@ -36,7 +36,7 @@ fdescribe("Unit - Google Analytic", () => {
 		fs.rmdirSync(`./output/${testFolder}`);
 	});
 
-	fit("Calling post should create post request to 'www.google-analytics.com", async () => {
+	it("Calling post should create post request to 'www.google-analytics.com", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({});
 
 		GATestClass.post({});

--- a/spec/unit/ProjectConfig-spec.ts
+++ b/spec/unit/ProjectConfig-spec.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 
 describe("Unit - ProjectConfig", () => {
-	it("hasLocalConfig returns correct values", async done => {
+	it("hasLocalConfig returns correct values", async () => {
 		const cwdSpy = spyOn(process, "cwd");
 		spyOn(os, "homedir").and.returnValues("rootDir");
 		spyOn(fs, "statSync").and.returnValue({ isFile: () => true });
@@ -16,7 +16,5 @@ describe("Unit - ProjectConfig", () => {
 		cwdSpy.and.returnValue("rootDir/somePath");
 		expect(ProjectConfig.hasLocalConfig()).toBeTruthy();
 		expect(fs.statSync).toHaveBeenCalledTimes(1);
-
-		done();
 	});
 });

--- a/spec/unit/PromptSession-spec.ts
+++ b/spec/unit/PromptSession-spec.ts
@@ -13,7 +13,7 @@ describe("Unit - PromptSession", () => {
 	});
 
 	// TODO: most of the tests use same setup - move the setup to beforeAll call
-	it("chooseTerm - Should call itself if no term is passed.", async done => {
+	it("chooseTerm - Should call itself if no term is passed.", async () => {
 		spyOn(PromptSession, "chooseTerm").and.callThrough();
 		spyOn(inquirer, "prompt").and.returnValues(Promise.resolve({ term: "" }),
 			Promise.resolve({ term: "" }), Promise.resolve({ term: "" }),
@@ -23,9 +23,8 @@ describe("Unit - PromptSession", () => {
 		expect(PromptSession.chooseTerm).toHaveBeenCalledTimes(5);
 		expect(testVar).toBe("Test");
 		expect(inquirer.prompt).toHaveBeenCalledTimes(5);
-		done();
 	});
-	it("start - Should create new project correctly", async done => {
+	it("start - Should create new project correctly", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({});
 		// tslint:disable:object-literal-sort-keys
 		const mockProject = {
@@ -98,9 +97,8 @@ describe("Unit - PromptSession", () => {
 		expect(inquirer.prompt).toHaveBeenCalledTimes(4);
 		expect(inquirer.prompt).toHaveBeenCalledWith(mockQuestion);
 		expect(mockTemplate.getFrameworkByName).toHaveBeenCalledTimes(1);
-		done();
 	});
-	it("start - Should go into chooseActionLoop if project has local config", async done => {
+	it("start - Should go into chooseActionLoop if project has local config", async () => {
 		const mockTemplate = jasmine.createSpyObj("mockTemplate", {
 			getProjectLibrary: {}
 		});
@@ -118,9 +116,8 @@ describe("Unit - PromptSession", () => {
 		expect(mockTemplate.getProjectLibrary).toHaveBeenCalledTimes(1);
 		expect(mockSession.chooseActionLoop).toHaveBeenCalledTimes(1);
 		expect(mockSession.chooseActionLoop).toHaveBeenCalledWith({});
-		done();
 	});
-	it("start - Should skip framework/projType input w/ restricted config", async done => {
+	it("start - Should skip framework/projType input w/ restricted config", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({
 			stepByStep: {
 				frameworks: ["angular"],
@@ -196,9 +193,8 @@ describe("Unit - PromptSession", () => {
 		expect(Util.log).toHaveBeenCalledWith(" Project structure generated.");
 		expect(Util.gitInit).toHaveBeenCalled();
 		expect(mockSession.chooseActionLoop).toHaveBeenCalled();
-		done();
 	});
-	it("start - New project - missing IFs", async done => {
+	it("start - New project - missing IFs", async () => {
 		// tslint:disable:object-literal-sort-keys
 		const mockProject = {
 			name: "Project 1",
@@ -284,9 +280,8 @@ describe("Unit - PromptSession", () => {
 		expect(Util.isAlphanumericExt).toHaveBeenCalledWith("Th15 w1ll");
 		expect(Util.directoryExists).toHaveBeenCalledTimes(3);
 		expect(Util.directoryExists).toHaveBeenCalledWith("Th15 w1ll");
-		done();
 	});
-	it("chooseActionLoop - should run through properly - Add Component", async done => {
+	it("chooseActionLoop - should run through properly - Add Component", async () => {
 		// tslint:disable:object-literal-sort-keys
 		const mockExtraConfigurations = [{
 			choices: [],
@@ -399,9 +394,8 @@ describe("Unit - PromptSession", () => {
 			name: "customValue2",
 			choices: []
 		}]);
-		done();
 	});
-	it("chooseActionLoop - should run through properly - Add scenario", async done => {
+	it("chooseActionLoop - should run through properly - Add scenario", async () => {
 		const mockSelectedTemplate = {
 			name: "Custom Template 1",
 			templates: [{
@@ -459,9 +453,8 @@ describe("Unit - PromptSession", () => {
 		expect(Util.getAvailableName).toHaveBeenCalledTimes(1);
 		expect(add.addTemplate).toHaveBeenCalledTimes(1);
 		expect(add.addTemplate).toHaveBeenCalledWith("Custom Template Name", mockSelectedTemplate);
-		done();
 	});
-	it("chooseActionLoop - should run through properly - Add Component", async done => {
+	it("chooseActionLoop - should run through properly - Add Component", async () => {
 		// tslint:disable:object-literal-sort-keys
 		const mockExtraConfigurations = [{
 			choices: ["Choice 1", "Choice 2", "Choice 3"],
@@ -584,9 +577,8 @@ describe("Unit - PromptSession", () => {
 			name: "customValue2",
 			choices: ["Choice 1", "Choice 2", "Choice 3"]
 		}]);
-		done();
 	});
-	it("chooseActionLoop - Complete and Run should update default port", async done => {
+	it("chooseActionLoop - Complete and Run should update default port", async () => {
 		const mockProject = {
 			generateConfig: () => Promise.resolve(true)
 		};
@@ -641,9 +633,8 @@ describe("Unit - PromptSession", () => {
 			"red");
 		expect(lastCallArgs.validate("3210")).toBe(true);
 		expect(Util.error).toHaveBeenCalledTimes(2);
-		done();
 	});
-	it("chooseActionLoop - should call `upgradePackages` when update angular is true", async done => {
+	it("chooseActionLoop - should call `upgradePackages` when update angular is true", async () => {
 		const params = {
 			project: {
 				defaultPort: 4200,
@@ -670,9 +661,8 @@ describe("Unit - PromptSession", () => {
 		expect(upgrade.upgrade).toHaveBeenCalledTimes(1);
 		expect(upgrade.upgrade).toHaveBeenCalledWith({ skipInstall: true });
 
-		done();
 	});
-	it("start - Should fire correctly with Angular Custom theme selected", async done => {
+	it("start - Should fire correctly with Angular Custom theme selected", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ customTemplates: [] });
 		const mockSession = new PromptSession(new TemplateManager());
 		spyOn(Util, "isAlphanumericExt").and.callThrough();
@@ -701,9 +691,8 @@ describe("Unit - PromptSession", () => {
 		const actualCall = (Util.processTemplates as jasmine.Spy).calls.argsFor(0)[2]["CustomTheme"].replace(/\s/g, "");
 		const expectedCall = CUSTOM_THEME.replace(/\s/g, "");
 		expect(actualCall).toEqual(expectedCall);
-		done();
 	});
-	it("start - Should fire correctly with Angular Default theme selected", async done => {
+	it("start - Should fire correctly with Angular Default theme selected", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ customTemplates: [] });
 		const mockSession = new PromptSession(new TemplateManager());
 		spyOn(Util, "isAlphanumericExt").and.callThrough();
@@ -723,6 +712,5 @@ describe("Unit - PromptSession", () => {
 		const actualCall = (Util.processTemplates as jasmine.Spy).calls.argsFor(0)[2]["DefaultTheme"].replace(/\s/g, "");
 		const expectedCall = DEFAULT_THEME.replace(/\s/g, "");
 		expect(actualCall).toEqual(expectedCall);
-		done();
 	});
 });

--- a/spec/unit/TemplateManager-spec.ts
+++ b/spec/unit/TemplateManager-spec.ts
@@ -36,7 +36,7 @@ describe("Unit - Template manager", () => {
 		});
 	});
 
-	it("Returns correct framework and projects", async done => {
+	it("Returns correct framework and projects", async () => {
 		const frameworkIds = ["react", "angular"];
 		mockProjLibs = frameworkIds.reduce((obj, folder) => {
 			obj[folder] = [
@@ -70,10 +70,9 @@ describe("Unit - Template manager", () => {
 		expect(manager.getProjectLibrary(frameworkIds[1], "test")).toBeUndefined();
 		expect(manager.getProjectLibrary(frameworkIds[1], frameworkIds[1] + "type1")).toBe(framework.projectLibraries[0]);
 		expect(manager.getProjectLibrary(frameworkIds[1], frameworkIds[1] + "type2")).toBe(framework.projectLibraries[1]);
-		done();
 	});
 
-	it("Shows warnings for incorrect custom templates", async done => {
+	it("Shows warnings for incorrect custom templates", async () => {
 		spyOn(Util, "error");
 		spyOn(Util, "getDirectoryNames").and.returnValue(["jquery"]);
 		const template = "existing/template/";
@@ -126,10 +125,9 @@ describe("Unit - Template manager", () => {
 			`The framework/project type for template with id "existing" is not supported.`);
 		expect(Util.error).toHaveBeenCalledWith(`File path: ${(template + "template.json").replace(/\//g, path.sep)}`);
 
-		done();
 	});
 
-	it("Loads custom templates from sub folders", async done => {
+	it("Loads custom templates from sub folders", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValues(
 			["jquery"], //frameworks load
 			["template1", "template2"] //templates load
@@ -163,10 +161,9 @@ describe("Unit - Template manager", () => {
 			jasmine.objectContaining({ id: "rootFolder/template2/template.json".replace(/\//g, path.sep) })
 		);
 
-		done();
 	});
 
-	it("Should load/create/register diff types of external custom Templates", async done => {
+	it("Should load/create/register diff types of external custom Templates", async () => {
 		spyOn(Util, "getDirectoryNames").and.returnValue(["jquery", "react", "angular"]);
 		const templates = [
 			"file:/template/jquery/js",
@@ -225,6 +222,5 @@ describe("Unit - Template manager", () => {
 		expect(mockProjLibs.angular[1].registerTemplate).toHaveBeenCalledWith(
 			jasmine.objectContaining(template("angular", "igx-ts"))
 		);
-		done();
 	});
 });

--- a/spec/unit/Util-spec.ts
+++ b/spec/unit/Util-spec.ts
@@ -1,7 +1,7 @@
 import { Util } from "@igniteui/cli-core";
 
 describe("Unit - Util", () => {
-	it("className should replace dashes and empty spaces", async done => {
+	it("className should replace dashes and empty spaces", async  => {
 		const projectNames = [
 			{
 				name: "name with spaces",
@@ -20,8 +20,6 @@ describe("Unit - Util", () => {
 		for (const item of projectNames) {
 			expect(Util.className(item.name)).toEqual(item.valid);
 		}
-
-		done();
 	});
 
 	it("should read the existing app folder name and return incremented app name ", () => {
@@ -78,7 +76,7 @@ describe("Unit - Util", () => {
 	});
 
 	describe("Relative paths", () => {
-		it("Creates correct relative path for child structure", async done => {
+		it("Creates correct relative path for child structure", async  => {
 
 			// default use, shared root
 			expect(Util.relativePath(
@@ -97,10 +95,9 @@ describe("Unit - Util", () => {
 				"C:/home/app/grid/grid.component.ts", true, false
 			))
 			.toBe("./app/grid/grid.component.ts", "Win style to posix file, keep ext => posix");
-			done();
 		});
 
-		it("Creates correct relative path for parent dir", async done => {
+		it("Creates correct relative path for parent dir", async  => {
 			// going up levels
 			expect(Util.relativePath(
 				"C:\\common\\folder1\\folder2\\folder3\\file.ts",
@@ -138,8 +135,6 @@ describe("Unit - Util", () => {
 				"C:\\common\\dir1\\dir2\\target.ts", true, false
 			))
 			.toBe("../../../dir1/dir2/target.ts", "posix folder to Win style file, keep ext => posix");
-
-			done();
 		});
 	});
 });

--- a/spec/unit/add-spec.ts
+++ b/spec/unit/add-spec.ts
@@ -13,7 +13,7 @@ describe("Unit - Add command", () => {
 		spyOn(GoogleAnalytics, "post");
 	});
 
-	it("Should start prompt session with missing arg", async done => {
+	it("Should start prompt session with missing arg", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
@@ -30,10 +30,9 @@ describe("Unit - Add command", () => {
 
 		await addCmd.execute({});
 		expect(promptSession.chooseActionLoop).toHaveBeenCalledWith(mockProjLib);
-		done();
 	});
 
-	it("Should validate and trim name", async done => {
+	it("Should validate and trim name", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
 			theme: "infragistics"}});
@@ -78,10 +77,9 @@ describe("Unit - Add command", () => {
 			expect(Util.processTemplates).toHaveBeenCalledWith("test", "Mock directory", mockConfig, mockDelimiters);
 		}
 
-		done();
 	});
 
-	it("Should queue package dependencies and wait for install", async done => {
+	it("Should queue package dependencies and wait for install", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
 			theme: "infragistics"}});
@@ -119,10 +117,9 @@ describe("Unit - Add command", () => {
 		expect(addCmd.addTemplate).toHaveBeenCalledWith("template with packages", {}, jasmine.any(Object));
 		expect(PackageManager.flushQueue).toHaveBeenCalled();
 
-		done();
 	});
 
-	it("Should properly accept module args when passed - IgniteUI for Angular", async done => {
+	it("Should properly accept module args when passed - IgniteUI for Angular", async () => {
 		const mockProjectConfig = {project: {
 			framework: "angular",
 			theme: "infragistics"
@@ -203,10 +200,9 @@ describe("Unit - Add command", () => {
 		});
 		expect(finalizeSpy).toHaveBeenCalledTimes(1);
 		expect(addCmd.templateManager.updateProjectConfiguration).toHaveBeenCalledTimes(1);
-		done();
 	});
 
-	it("Should properly accept module args when passed - Angular Wrappers", async done => {
+	it("Should properly accept module args when passed - Angular Wrappers", async () => {
 		const mockProjectConfig = {project: {
 			framework: "angular",
 			theme: "infragistics"
@@ -277,10 +273,9 @@ describe("Unit - Add command", () => {
 		});
 		expect(finalizeSpy).toHaveBeenCalledTimes(1);
 		expect(addCmd.templateManager.updateProjectConfiguration).toHaveBeenCalledTimes(1);
-		done();
 	});
 
-	it("Should properly accept skip-route args when passed", async done => {
+	it("Should properly accept skip-route args when passed", async () => {
 		const mockProjectConfig = {project: {
 			framework: "angular",
 			theme: "infragistics"
@@ -331,10 +326,9 @@ describe("Unit - Add command", () => {
 			jasmine.objectContaining({ skipRoute: true })
 		);
 		expect(addCmd.templateManager.updateProjectConfiguration).toHaveBeenCalledWith(mockTemplate);
-		done();
 	});
 
-	it("Should not add component and should log error if wrong path is passed to module", async done => {
+	it("Should not add component and should log error if wrong path is passed to module", async () => {
 		spyOn(Util, "fileExists").and.returnValue(false);
 		spyOn(Util, "error");
 		const wrongPath = "myCustomModule/my-custom-module.module.ts";
@@ -342,6 +336,5 @@ describe("Unit - Add command", () => {
 		expect(Util.fileExists).toHaveBeenCalledTimes(1);
 		expect(Util.error).toHaveBeenCalledTimes(1);
 		expect(Util.error).toHaveBeenCalledWith(`Wrong module path provided: ${wrongPath}. No components were added!`);
-		done();
 	});
 });

--- a/spec/unit/base-templates/AngularTemplate-spec.ts
+++ b/spec/unit/base-templates/AngularTemplate-spec.ts
@@ -15,7 +15,7 @@ describe("Unit - AngularTemplate Base", () => {
 		public widget = "widget no-process";
 	}
 
-	it("generateConfig call processTemplates with correct path and variables", async done => {
+	it("generateConfig call processTemplates with correct path and variables", async () => {
 		const expected = {
 			name: "my component",
 			ClassName: "MyComponent",
@@ -40,10 +40,9 @@ describe("Unit - AngularTemplate Base", () => {
 		// 	path.join("root/path" , "files"),
 		// 	"/target/path",
 		// 	expected, {});
-		done();
 	});
 
-	it("generateConfig merge passed variables under extraConfig (only)", async done => {
+	it("generateConfig merge passed variables under extraConfig (only)", async () => {
 		const expected = {
 			name: "page",
 			ClassName: "Page",
@@ -53,19 +52,21 @@ describe("Unit - AngularTemplate Base", () => {
 			// widget
 			widget: "widget no-process",
 			// extra
-			extraConfig1 : "extraConfig1",
+			extraConfig1: "extraConfig1",
 			camelCaseName: "page",
-			gridFeatures : "{ features }",
+			gridFeatures: "{ features }",
 			cliVersion: Util.version()
 		};
 		spyOn(Util, "processTemplates");
 		// const validateSpy = spyOn<any>(Util, "validateTemplate").and.returnValue(true);
 
 		const templ = new TestWidgetTemplate("root");
-		let actual = templ.generateConfig("page", { extraConfig : {
-			extraConfig1 : "extraConfig1",
-			gridFeatures : "{ features }"
-		} });
+		let actual = templ.generateConfig("page", {
+			extraConfig: {
+				extraConfig1: "extraConfig1",
+				gridFeatures: "{ features }"
+			}
+		});
 		expect(actual).toEqual(expected);
 		// expect(validateSpy).toHaveBeenCalledWith(
 		// 	path.join("root" , "files"),
@@ -76,15 +77,14 @@ describe("Unit - AngularTemplate Base", () => {
 		// 	"/target/path",
 		// 	expected, {});
 		actual = templ.generateConfig("page", {
-			extraConfig : {
-				extraConfig1 : "extraConfig1",
-				gridFeatures : "{ features }"
+			extraConfig: {
+				extraConfig1: "extraConfig1",
+				gridFeatures: "{ features }"
 			},
 			someOtherVar: "some/some.module.ts",
 			someThirdVar: false
 		});
 		expect(actual).toEqual(expected);
-		done();
 	});
 
 	describe("registerInProject", () => {
@@ -93,9 +93,15 @@ describe("Unit - AngularTemplate Base", () => {
 			helpers = {
 				tsUpdateMock: jasmine.createSpyObj(
 					"TypeScriptFileUpdate", ["addRoute", "addDeclaration", "finalize"]) as TypeScriptFileUpdate,
-				TypeScriptFileUpdate: () => helpers.tsUpdateMock,
+				//tslint:disable
+				TypeScriptFileUpdate: function (_a) {
+					this.addRoute = (...args: any) => { };
+					this.addDeclaration = (...args: any) => { };
+					this.finalize = (...args: any) => { };
+				},
 				requireMock: require
 			};
+			//tslint:enable
 			// spy on require:
 			spyOn(require("module"), "_load").and.callFake((modulePath: string) => {
 				if (modulePath.endsWith("@igniteui/cli-core/typescript")) {
@@ -104,13 +110,13 @@ describe("Unit - AngularTemplate Base", () => {
 					return { dv: ["igDvWidget"] };
 				}
 			});
-			spyOn(helpers, "TypeScriptFileUpdate").and.callThrough();
+			spyOn(helpers, "TypeScriptFileUpdate").and.returnValue(helpers.tsUpdateMock);
 			// return through function to get new obj ref each time
 			spyOn(ProjectConfig, "getConfig").and.callFake(() => ({ project: { sourceFiles: ["existing"] } }));
 			spyOn(ProjectConfig, "setConfig");
 		});
 
-		it("registers route and declare component", async done => {
+		it("registers route and declare component", async () => {
 			const templ = new TestTemplate();
 			templ.registerInProject("target/path", "view name");
 			expect(helpers.TypeScriptFileUpdate).toHaveBeenCalledWith(path.join("target/path", "src/app/app-routing.module.ts"));
@@ -129,9 +135,8 @@ describe("Unit - AngularTemplate Base", () => {
 
 			//config update:
 			expect(ProjectConfig.setConfig).toHaveBeenCalledTimes(0);
-			done();
 		});
-		it("should skip route if skipRoute is passed", async done => {
+		it("should skip route if skipRoute is passed", async () => {
 			const templ = new TestTemplate();
 			templ.registerInProject("target/path", "view name", { skipRoute: true });
 			expect(helpers.tsUpdateMock.addRoute).toHaveBeenCalledTimes(0);
@@ -147,33 +152,37 @@ describe("Unit - AngularTemplate Base", () => {
 
 			//config update:
 			expect(ProjectConfig.setConfig).toHaveBeenCalledTimes(0);
-			done();
 		});
-		it("updates project config", async done => {
+		it("updates project config", async () => {
 			const templ = new TestTemplate();
 			templ.dependencies.push("igDvWidget");
 			templ.registerInProject("", "");
-			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ project: {
-				sourceFiles: ["existing", "infragistics.dv.js"]
-			} });
+			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({
+				project: {
+					sourceFiles: ["existing", "infragistics.dv.js"]
+				}
+			});
 
 			templ.dependencies.push("igExcel");
 			templ.registerInProject("", "");
-			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ project: {
-				sourceFiles: ["existing", "infragistics.dv.js", "infragistics.excel-bundled.js"]
-			} });
+			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({
+				project: {
+					sourceFiles: ["existing", "infragistics.dv.js", "infragistics.excel-bundled.js"]
+				}
+			});
 
 			templ.dependencies.push("igGridExcelExporter");
 			templ.registerInProject("", "");
-			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ project: {
-				sourceFiles: [
-					"existing",
-					"infragistics.dv.js",
-					"infragistics.excel-bundled.js",
-					"modules/infragistics.gridexcelexporter.js"
-				]
-			} });
-			done();
+			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({
+				project: {
+					sourceFiles: [
+						"existing",
+						"infragistics.dv.js",
+						"infragistics.excel-bundled.js",
+						"modules/infragistics.gridexcelexporter.js"
+					]
+				}
+			});
 		});
 	});
 });

--- a/spec/unit/base-templates/IgniteUIForAngularTemplate-spec.ts
+++ b/spec/unit/base-templates/IgniteUIForAngularTemplate-spec.ts
@@ -21,9 +21,13 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 				requireMock: require,
 				tsUpdateMock: jasmine.createSpyObj(
 					"TypeScriptFileUpdate", ["addRoute", "addDeclaration", "addNgModuleMeta", "finalize"]) as TypeScriptFileUpdate,
-				TypeScriptFileUpdate: (...args) => {
-					return helpers.tsUpdateMock;
-				}
+				//tslint:disable
+				TypeScriptFileUpdate: function (_a) {
+					this.addRoute = (...args: any) => { };
+					this.addDeclaration = (...args: any) => { };
+					this.finalize = (...args: any) => { };
+					this.addNgModuleMeta = (...args: any) => { };
+				},
 			};
 			App.initialize();
 			// spy on require:
@@ -36,13 +40,13 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 			});
 			// spy on version due to require override
 			spyOn(Util, "version").and.returnValue("1.0.0");
-			spyOn(helpers, "TypeScriptFileUpdate").and.callThrough();
+			spyOn(helpers, "TypeScriptFileUpdate").and.returnValue(helpers.tsUpdateMock);
 			// return through function to get new obj ref each time
 			spyOn(ProjectConfig, "getConfig").and.callFake(() => ({ project: { sourceFiles: ["existing"] } }));
 			spyOn(ProjectConfig, "setConfig");
 		});
 
-		it("registers route and declare component", async done => {
+		it("registers route and declare component", async () => {
 			const templ = new TestTemplate();
 			const mockFS = {
 				fileExists: () => {}
@@ -72,9 +76,8 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 			expect(helpers.tsUpdateMock.finalize).toHaveBeenCalled();
 			//config update:
 			expect(ProjectConfig.setConfig).toHaveBeenCalledTimes(0);
-			done();
 		});
-		it("updates NgModule metadata", async done => {
+		it("updates NgModule metadata", async () => {
 			const templ = new TestTemplate();
 			templ.dependencies.push({ import: "test", from: "test" });
 			templ.registerInProject("", "");
@@ -93,9 +96,8 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 				{ declare: "test2", provide: "test2" },
 				Util.applyDelimiters(templ.getBaseVariables(""), templ.delimiters.content));
 
-			done();
 		});
-		it("formats relative imports", async done => {
+		it("formats relative imports", async () => {
 			spyOn(TestTemplate.prototype, "getBaseVariables").and.returnValue({});
 			spyOn(Util, "relativePath").and.returnValue("./relative/result/test");
 			const mainPath = path.join("target", "src/app/app.module.ts");
@@ -108,10 +110,9 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 			expect(Util.relativePath).toHaveBeenCalledWith(mainPath, filePath, true, true);
 			expect(helpers.tsUpdateMock.addNgModuleMeta).toHaveBeenCalledWith({ from: "./relative/result/test" }, {});
 
-			done();
 		});
 
-		it("should skip route if skipRoute is passed", async done => {
+		it("should skip route if skipRoute is passed", async () => {
 			const templ = new TestTemplate();
 			templ.registerInProject("target/path", "view name", { skipRoute: true });
 			expect(helpers.tsUpdateMock.addRoute).toHaveBeenCalledTimes(0);
@@ -126,10 +127,9 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 			);
 			expect(helpers.tsUpdateMock.addNgModuleMeta).toHaveBeenCalledTimes(0);
 			expect(helpers.tsUpdateMock.finalize).toHaveBeenCalled();
-			done();
 		});
 
-		it("generateConfig merges variables passed under extraConfig", async done => {
+		it("generateConfig merges variables passed under extraConfig", async () => {
 			const expected = {
 				camelCaseName: "test",
 				ClassName: "Test",
@@ -168,7 +168,6 @@ describe("Unit - IgniteUIForAngularTemplate Base", () => {
 			expected.igxPackage = FEED_PACKAGE;
 			actual = templ.generateConfig("test", options);
 			expect(actual).toEqual(expected);
-			done();
 		});
 	});
 });

--- a/spec/unit/cli-spec.ts
+++ b/spec/unit/cli-spec.ts
@@ -14,64 +14,55 @@ describe("Unit - Cli.ts", () => {
 	});
 
 	/*
-	it("Should fire properly - XX", async done => {
+	it("Should fire properly - XX", async () => {
 		spyOn(XX , "YY");
 		await run.run("--XX");
 		expect(XX.YY).toHaveBeenCalled();
-		done();
 	});
 	*/
-	it("Should fire properly - Version", async done => {
+	it("Should fire properly - Version", async () => {
 		spyOn(Util, "showVersion");
 		await run.run("--version");
 		expect(Util.showVersion).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - quickstart", async done => {
+	it("Should fire properly - quickstart", async () => {
 		spyOn(quickstart , "execute").and.returnValue(Promise.resolve(true));
 		spyOn(Util , "log");
 		await run.run("quickstart");
 		expect(quickstart.execute).toHaveBeenCalled();
 		expect(Util.log).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - add", async done => {
+	it("Should fire properly - add", async () => {
 		spyOn(add , "check").and.returnValue(false);
 		await run.run("add");
 		expect(add.check).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - build", async done => {
+	it("Should fire properly - build", async () => {
 		spyOn(build , "execute").and.returnValue(true);
 		await run.run("build");
 		expect(build.execute).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - doc", async done => {
+	it("Should fire properly - doc", async () => {
 		spyOn(doc , "execute").and.returnValue(true);
 		await run.run("doc");
 		expect(doc.execute).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - test", async done => {
+	it("Should fire properly - test", async () => {
 		spyOn(test , "execute").and.returnValue(true);
 		await run.run("test");
 		expect(test.execute).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - start", async done => {
+	it("Should fire properly - start", async () => {
 		spyOn(start , "execute").and.returnValue(true);
 		await run.run("start");
 		expect(start.execute).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - list", async done => {
+	it("Should fire properly - list", async () => {
 		spyOn(list , "execute").and.returnValue(true);
 		await run.run("list");
 		expect(list.execute).toHaveBeenCalled();
-		done();
 	});
-	it("Should fire properly - fallback to default", async done => {
+	it("Should fire properly - fallback to default", async () => {
 		spyOn(Util , "log");
 		spyOn(GoogleAnalytics, "post");
 		spyOn(PromptSession.prototype, "start");
@@ -81,6 +72,5 @@ describe("Unit - Cli.ts", () => {
 		expect(Util.log).toHaveBeenCalledWith("Starting Step by step mode.", "green");
 		expect(Util.log).toHaveBeenCalledWith("For available commands, stop this execution and use --help.", "green");
 		expect(PromptSession.prototype.start).toHaveBeenCalled();
-		done();
 	});
 });

--- a/spec/unit/config-spec.ts
+++ b/spec/unit/config-spec.ts
@@ -7,16 +7,15 @@ describe("Unit - Config command", () => {
 	});
 
 	describe("Get", () => {
-		it("Should show error w/o existing project and global flag", async done => {
+		it("Should show error w/o existing project and global flag", async () => {
 			spyOn(Util, "error");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
 
 			await configCmd.getHandler({ property: "test" });
 			expect(Util.error).toHaveBeenCalledWith("No configuration file found in this folder!", "red");
-			done();
 		});
 
-		it("Should show error for missing prop", async done => {
+		it("Should show error for missing prop", async () => {
 			spyOn(Util, "error");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "getConfig").and.returnValue({ notTest: "ig" });
@@ -24,10 +23,9 @@ describe("Unit - Config command", () => {
 			await configCmd.getHandler({ property: "test" });
 			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(undefined);
 			expect(Util.error).toHaveBeenCalledWith(`No value found for "test" property`, "red");
-			done();
 		});
 
-		it("Should show error for missing prop and global flag", async done => {
+		it("Should show error for missing prop and global flag", async () => {
 			spyOn(Util, "error");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "getConfig").and.returnValue({ notTest: "ig" });
@@ -35,10 +33,9 @@ describe("Unit - Config command", () => {
 			await configCmd.getHandler({ property: "test", global: true });
 			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(true);
 			expect(Util.error).toHaveBeenCalledWith(`No value found for "test" property`, "red");
-			done();
 		});
 
-		it("Should return value for property", async done => {
+		it("Should return value for property", async () => {
 			spyOn(Util, "log");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "getConfig").and.returnValue({ test: "igValue" });
@@ -46,7 +43,6 @@ describe("Unit - Config command", () => {
 			await configCmd.getHandler({ property: "test" });
 			expect(ProjectConfig.getConfig).toHaveBeenCalledWith(undefined);
 			expect(Util.log).toHaveBeenCalledWith("igValue");
-			done();
 		});
 	});
 
@@ -75,15 +71,14 @@ describe("Unit - Config command", () => {
 			);
 		});
 
-		it("Should show error w/o existing project and global flag", async done => {
+		it("Should show error w/o existing project and global flag", async () => {
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
 
 			await configCmd.setHandler({ property: "test", value: true });
 			expect(Util.error).toHaveBeenCalledWith("No configuration file found in this folder!", "red");
-			done();
 		});
 
-		it("Should show error when invalid value provided", async done => {
+		it("Should show error when invalid value provided", async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ booleanProperty: true });
 
 			await configCmd.setHandler({ property: "booleanProperty", value: "non boolean value", global: true });
@@ -91,10 +86,9 @@ describe("Unit - Config command", () => {
 			expect(Util.error).toHaveBeenCalledTimes(1);
 			expect(Util.error).toHaveBeenCalledWith("Invalid value provided for booleanProperty property", "red");
 			expect(Util.log).toHaveBeenCalledTimes(0);
-			done();
 		});
 
-		it("Should show error when invalid value type provided", async done => {
+		it("Should show error when invalid value type provided", async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ booleanProperty: true });
 
 			await configCmd.setHandler({ property: "booleanProperty", value: '{ "object-Value": "for boolean"}', global: true });
@@ -103,10 +97,9 @@ describe("Unit - Config command", () => {
 			expect(Util.error).toHaveBeenCalledWith(
 				"Invalid value type provided for booleanProperty property\nValue should be of type boolean", "red");
 			expect(Util.log).toHaveBeenCalledTimes(0);
-			done();
 		});
 
-		it("Should show error for array property", async done => {
+		it("Should show error for array property", async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ arrayProperty: [] });
 
 			// tslint:disable-next-line:quotemark
@@ -115,10 +108,9 @@ describe("Unit - Config command", () => {
 			expect(Util.error).toHaveBeenCalledTimes(1);
 			expect(Util.error).toHaveBeenCalledWith("Provided value should be an empty array for arrayProperty property", "red");
 			expect(Util.log).toHaveBeenCalledTimes(0);
-			done();
 		});
 
-		it("Should reset array property when empty array is provided", async done => {
+		it("Should reset array property when empty array is provided", async () => {
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ arrayProperty: ["Some value", "More values"] });
 			spyOn(ProjectConfig, "setConfig");
 
@@ -128,10 +120,9 @@ describe("Unit - Config command", () => {
 			expect(Util.log).toHaveBeenCalledTimes(1);
 			expect(Util.log).toHaveBeenCalledWith("Property \"arrayProperty\" set.");
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ arrayProperty: [] }, true /*global*/);
-			done();
 		});
 
-		it("Should set global prop", async done => {
+		it("Should set global prop", async () => {
 			spyOn(ProjectConfig, "hasLocalConfig");
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ stringProperty: "ig" });
 			spyOn(ProjectConfig, "localConfig");
@@ -144,10 +135,9 @@ describe("Unit - Config command", () => {
 			expect(ProjectConfig.globalConfig).toHaveBeenCalled();
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ stringProperty: true }, true /*global*/);
 			expect(Util.log).toHaveBeenCalledWith(`Property "stringProperty" set.`);
-			done();
 		});
 
-		it("Should set local prop", async done => {
+		it("Should set local prop", async () => {
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "localConfig").and.returnValue({ stringProperty: "ig" });
 			spyOn(ProjectConfig, "globalConfig");
@@ -158,21 +148,19 @@ describe("Unit - Config command", () => {
 			expect(ProjectConfig.localConfig).toHaveBeenCalled();
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ stringProperty: "ig", booleanProperty: true }, undefined);
 			expect(Util.log).toHaveBeenCalledWith(`Property "booleanProperty" set.`);
-			done();
 		});
 	});
 
 	describe("Add", () => {
-		it("Should show error w/o existing project and global flag", async done => {
+		it("Should show error w/o existing project and global flag", async () => {
 			spyOn(Util, "error");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
 
 			await configCmd.addHandler({ property: "test", value: true });
 			expect(Util.error).toHaveBeenCalledWith("No configuration file found in this folder!", "red");
-			done();
 		});
 
-		it("Should show error for non-array property", async done => {
+		it("Should show error for non-array property", async () => {
 			spyOn(Util, "error");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "localConfig").and.returnValue({ test: "notArray" });
@@ -181,20 +169,19 @@ describe("Unit - Config command", () => {
 			expect(Util.error).toHaveBeenCalledWith(
 				`Configuration property "test" is not an array, use config set instead.`,
 				"red");
-			done();
+
 		});
 
-		it("Should skip existing", async done => {
+		it("Should skip existing", async () => {
 			spyOn(Util, "log");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "localConfig").and.returnValue({ test: ["existing"] });
 
 			await configCmd.addHandler({ property: "test", value: "existing" });
 			expect(Util.log).toHaveBeenCalledWith(`Value already exists in "test".`);
-			done();
 		});
 
-		it("Should create/add to global prop", async done => {
+		it("Should create/add to global prop", async () => {
 			spyOn(Util, "log");
 			spyOn(ProjectConfig, "globalConfig").and.returnValue({ });
 			spyOn(ProjectConfig, "setConfig");
@@ -206,10 +193,9 @@ describe("Unit - Config command", () => {
 			await configCmd.addHandler({ property: "test", value: "two", global: true });
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ test: ["one", "two"] }, true);
 			expect(Util.log).toHaveBeenCalledWith(`Property "test" updated.`);
-			done();
 		});
 
-		it("Should add to local prop", async done => {
+		it("Should add to local prop", async () => {
 			spyOn(Util, "log");
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "localConfig").and.returnValue({ test: [] });
@@ -218,7 +204,6 @@ describe("Unit - Config command", () => {
 			await configCmd.addHandler({ property: "test", value: "first" });
 			expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ test: ["first"] }, undefined);
 			expect(Util.log).toHaveBeenCalledWith(`Property "test" updated.`);
-			done();
 		});
 	});
 });

--- a/spec/unit/doc-spec.ts
+++ b/spec/unit/doc-spec.ts
@@ -7,7 +7,7 @@ describe("Unit - Doc command", () => {
 		spyOn(GoogleAnalytics, "post");
 	});
 
-	it("Should search Infragistics API for passed term", async done => {
+	it("Should search Infragistics API for passed term", async () => {
 		spyOn(doc, "execute").and.callThrough();
 		spyOn(doc, "open");
 		spyOn(Util, "log");
@@ -19,9 +19,8 @@ describe("Unit - Doc command", () => {
 		expect(doc.execute).toHaveBeenCalledTimes(1);
 		expect(doc.open).toHaveBeenCalledWith("https://www.infragistics.com/search?q=igGrid");
 		expect(Util.log).toHaveBeenCalledWith(`Review your search results in the browser`, "green");
-		done();
 	});
-	it("Should propmpt user for input if called without arguments", async done => {
+	it("Should propmpt user for input if called without arguments", async () => {
 		spyOn(doc, "execute").and.callThrough();
 		spyOn(PromptSession, "chooseTerm").and.returnValue(Promise.resolve("igGrid"));
 		spyOn(doc, "open");
@@ -35,9 +34,8 @@ describe("Unit - Doc command", () => {
 		expect(doc.open).toHaveBeenCalledTimes(1);
 		expect(doc.open).toHaveBeenCalledWith("https://www.infragistics.com/search?q=igGrid");
 		expect(Util.log).toHaveBeenCalledWith(`Review your search results in the browser`, "green");
-		done();
 	});
-	it("Should raise an error if search term does no match criteria", async done => {
+	it("Should raise an error if search term does no match criteria", async () => {
 		spyOn(doc, "execute").and.callThrough();
 		spyOn(Util, "error");
 		await doc.execute({
@@ -47,6 +45,5 @@ describe("Unit - Doc command", () => {
 		expect(Util.error).toHaveBeenCalled();
 		expect(Util.error).toHaveBeenCalledWith("The search term 'Th1s i$ incorrect' is not valid." + "\n" +
 "Name should start with a letter and can also contain numbers, dashes and spaces.", "red");
-		done();
 	});
 });

--- a/spec/unit/generate-spec.ts
+++ b/spec/unit/generate-spec.ts
@@ -1,4 +1,4 @@
-import { GoogleAnalytics, Util } from "@igniteui/cli-core";
+import { GoogleAnalytics, ProjectConfig, Util } from "@igniteui/cli-core";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -23,7 +23,7 @@ describe("Unit - Generate command", () => {
 
 		// ~/.global/ homedir for global files:
 		fs.mkdirSync(`.global`);
-		spyOn(os, "homedir").and.returnValue(path.join(process.cwd(), ".global"));
+		ProjectConfig.os = { homedir: () => path.join(process.cwd(), ".global") } as any;
 
 		spyOn(Util, "error");
 		spyOn(Util, "log");
@@ -35,7 +35,7 @@ describe("Unit - Generate command", () => {
 		fs.rmdirSync(`./output/${testFolder}`);
 	});
 
-	it("Should generate template pass with correct values", async done => {
+	it("Should generate template pass with correct values", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(false);
 		spyOn(Util, "processTemplates").and.returnValue(new Promise<boolean>((res, rej) => { res(true); }));
@@ -82,11 +82,9 @@ describe("Unit - Generate command", () => {
 		};
 		expect(config.addHandler).toHaveBeenCalledTimes(1);
 		expect(config.addHandler).toHaveBeenCalledWith(addHandlerExpectedParameter);
-
-		done();
 	});
 
-	it("Logs error for wrong name", async done => {
+	it("Logs error for wrong name", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(false);
 
 		await generateCmd.template({ name: "123wrongName", framework: "jquery", type: "js" });
@@ -97,11 +95,9 @@ describe("Unit - Generate command", () => {
 			"red");
 
 		expect(Util.log).not.toHaveBeenCalled();
-
-		done();
 	});
 
-	it("Logs error for existing folder", async done => {
+	it("Logs error for existing folder", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(true);
 
@@ -113,11 +109,9 @@ describe("Unit - Generate command", () => {
 		expect(Util.error).toHaveBeenCalledWith("Folder 'custom-template' already exists!", "red");
 
 		expect(Util.log).not.toHaveBeenCalled();
-
-		done();
 	});
 
-	it("Logs error for wrong framework", async done => {
+	it("Logs error for wrong framework", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(false);
 
@@ -131,11 +125,9 @@ describe("Unit - Generate command", () => {
 		expect(Util.error).toHaveBeenCalledWith("Framework not supported", "red");
 
 		expect(Util.log).not.toHaveBeenCalled();
-
-		done();
 	});
 
-	it("Logs error for wrong type", async done => {
+	it("Logs error for wrong type", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(false);
 
@@ -150,11 +142,9 @@ describe("Unit - Generate command", () => {
 		expect(Util.error).toHaveBeenCalledWith("Project type 'wrongType' not found in framework 'jquery'");
 
 		expect(Util.log).not.toHaveBeenCalled();
-
-		done();
 	});
 
-	it("Logs error if generate template fail", async done => {
+	it("Logs error if generate template fail", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(false);
 		spyOn(Util, "processTemplates").and.returnValue(new Promise<boolean>((res, rej) => { res(false); }));
@@ -170,11 +160,9 @@ describe("Unit - Generate command", () => {
 		expect(Util.error).toHaveBeenCalledWith("Template generation failed!", "red");
 
 		expect(Util.log).not.toHaveBeenCalled();
-
-		done();
 	});
 
-	it("Should not add path to global config if skip-config is true", async done => {
+	it("Should not add path to global config if skip-config is true", async () => {
 		spyOn(Util, "isAlphanumericExt").and.returnValue(true);
 		spyOn(Util, "directoryExists").and.returnValue(false);
 		spyOn(Util, "processTemplates").and.returnValue(new Promise<boolean>((res, rej) => { res(true); }));
@@ -197,7 +185,5 @@ describe("Unit - Generate command", () => {
 		expect(Util.log).toHaveBeenCalledWith("Template generated successfully");
 
 		expect(config.addHandler).not.toHaveBeenCalled();
-
-		done();
 	});
 });

--- a/spec/unit/gridHelper-spec.ts
+++ b/spec/unit/gridHelper-spec.ts
@@ -1,7 +1,7 @@
 import {FeatureOutputType, GridHelper} from "../../packages/cli/lib/project-utility/GridHelper";
 
 describe("Unit Tests - GridHelper", () => {
-	it("Should call generateFeatures properly - AngularJS", async done => {
+	it("Should call generateFeatures properly - AngularJS", async () => {
 		const mockGridHelper = new GridHelper();
 		mockGridHelper.outputType = FeatureOutputType.AngularJS;
 		spyOn(mockGridHelper, "addFeature").and.callThrough();
@@ -9,9 +9,8 @@ describe("Unit Tests - GridHelper", () => {
 		mockGridHelper.generateFeatures(["Feature 1", "Feature 2"], 0);
 		expect(mockGridHelper.addFeature).toHaveBeenCalledTimes(2);
 		expect(mockGenerate).toHaveBeenCalledTimes(1);
-		done();
 	});
-	it("Should call generateFeatures properly - JS", async done => {
+	it("Should call generateFeatures properly - JS", async () => {
 		const mockGridHelper = new GridHelper();
 		mockGridHelper.outputType = FeatureOutputType.JS;
 		spyOn(mockGridHelper, "addFeature");
@@ -19,9 +18,8 @@ describe("Unit Tests - GridHelper", () => {
 		mockGridHelper.generateFeatures(["Feature 1", "Feature 2"], 0);
 		expect(mockGridHelper.addFeature).toHaveBeenCalledTimes(2);
 		expect(JSON.stringify).toHaveBeenCalledTimes(1);
-		done();
 	});
-	it("Should call addFeature properly - with Selection", async done => {
+	it("Should call addFeature properly - with Selection", async () => {
 		const mockGridHelper = new GridHelper();
 		mockGridHelper.outputType = FeatureOutputType.AngularJS;
 		const mockGetFeature = spyOn<any>(mockGridHelper, "getFeature");
@@ -29,9 +27,8 @@ describe("Unit Tests - GridHelper", () => {
 		expect(mockGetFeature).toHaveBeenCalledTimes(2);
 		expect(mockGetFeature).toHaveBeenCalledWith("Selection");
 		expect(mockGetFeature).toHaveBeenCalledWith("RowSelectors");
-		done();
 	});
-	it("Should call addFeature properly - without Selection", async done => {
+	it("Should call addFeature properly - without Selection", async () => {
 		const mockGridHelper = new GridHelper();
 		mockGridHelper.outputType = FeatureOutputType.AngularJS;
 		mockGridHelper.hierarchical = true;
@@ -39,6 +36,5 @@ describe("Unit Tests - GridHelper", () => {
 		mockGridHelper.addFeature("Example");
 		expect(mockGetFeature).toHaveBeenCalledTimes(1);
 		expect(mockGetFeature).toHaveBeenCalledWith("Example");
-		done();
 	});
 });

--- a/spec/unit/list-spec.ts
+++ b/spec/unit/list-spec.ts
@@ -22,7 +22,7 @@ describe("Unit - List command", () => {
 	afterEach(() => {
 	});
 
-	it("Should list all templates with correctly provided parameters", async done => {
+	it("Should list all templates with correctly provided parameters", async () => {
 		const framework = { name: "jQuery" };
 		const projectLib = {
 			projectType: "js",
@@ -47,11 +47,9 @@ describe("Unit - List command", () => {
 		expect(Util.log).toHaveBeenCalledWith("'group2' group:");
 		expect(Util.log).toHaveBeenCalledWith("	id2.1     Description for 2.1");
 		expect(Util.log).toHaveBeenCalledWith("	id2.2     Description for 2.2");
-
-		done();
 	});
 
-	it("Should list templates for framework specified in local config if any", async done => {
+	it("Should list templates for framework specified in local config if any", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		spyOn(ProjectConfig, "getConfig").and.returnValue({
 			project: {
@@ -85,11 +83,9 @@ describe("Unit - List command", () => {
 		expect(Util.log).toHaveBeenCalledWith("	id2.2     Description for 2.2");
 		expect(Util.log).toHaveBeenCalledWith(
 			"To list available templates for other framework and project type run outside of a project folder");
-
-		done();
 	});
 
-	it("Should log error if called with wrong framework", async done => {
+	it("Should log error if called with wrong framework", async () => {
 		listCmd.templateManager = jasmine.createSpyObj("TemplateManager", {
 			getFrameworkById: undefined
 		});
@@ -98,11 +94,9 @@ describe("Unit - List command", () => {
 
 		expect(Util.error).toHaveBeenCalledTimes(1);
 		expect(Util.error).toHaveBeenCalledWith("Wrong framework provided", "red");
-
-		done();
 	});
 
-	it("Should log error if called without framework outside a project", async done => {
+	it("Should log error if called without framework outside a project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
 		listCmd.templateManager = jasmine.createSpyObj("TemplateManager", {
 			getFrameworkById: undefined
@@ -112,11 +106,9 @@ describe("Unit - List command", () => {
 
 		expect(Util.error).toHaveBeenCalledTimes(1);
 		expect(Util.error).toHaveBeenCalledWith("Wrong framework provided", "red");
-
-		done();
 	});
 
-	it("Should log error if called with wrong type", async done => {
+	it("Should log error if called with wrong type", async () => {
 		listCmd.templateManager = jasmine.createSpyObj("TemplateManager", {
 			getFrameworkById: {},
 			getProjectLibrary: undefined
@@ -126,11 +118,9 @@ describe("Unit - List command", () => {
 
 		expect(Util.error).toHaveBeenCalledTimes(1);
 		expect(Util.error).toHaveBeenCalledWith("Project type 'wrongType' not found in framework 'angular'", "red");
-
-		done();
 	});
 
-	it("Should list templates for default type when type no provided", async done => {
+	it("Should list templates for default type when type no provided", async () => {
 		const framework = { name: "React" };
 		const projectLib = {
 			projectType: "es6",
@@ -155,7 +145,5 @@ describe("Unit - List command", () => {
 		expect(Util.log).toHaveBeenCalledWith("'group2' group:");
 		expect(Util.log).toHaveBeenCalledWith("	id2.1     Description for 2.1");
 		expect(Util.log).toHaveBeenCalledWith("	id2.2     Description for 2.2");
-
-		done();
 	});
 });

--- a/spec/unit/new-spec.ts
+++ b/spec/unit/new-spec.ts
@@ -21,16 +21,15 @@ describe("Unit - New command", () => {
 		process.chdir("../../");
 	});
 
-	it("New command in existing project", async done => {
+	it("New command in existing project", async () => {
 		spyOn(Util, "error");
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 
 		await newCmd.execute({});
 		expect(Util.error).toHaveBeenCalledWith("There is already an existing project.", "red");
-		done();
 	});
 
-	it("Should validate and trim name", async done => {
+	it("Should validate and trim name", async () => {
 		spyOn(Util, "error");
 		spyOn(ProjectConfig, "getConfig").and.returnValue(null);
 
@@ -52,10 +51,9 @@ describe("Unit - New command", () => {
 				"red");
 		}
 
-		done();
 	});
 
-	it("Logs error for wrong framework", async done => {
+	it("Logs error for wrong framework", async () => {
 		spyOn(Util, "error");
 		//spied getFrameworkById won't return anything, i.e. not found
 		newCmd.template = jasmine.createSpyObj("TemplateManager", ["getFrameworkById", "getProjectLibrary"]);
@@ -67,10 +65,9 @@ describe("Unit - New command", () => {
 		//no further attempts to get project:
 		expect(newCmd.template.getProjectLibrary).toHaveBeenCalledTimes(0);
 		expect(Util.log).toHaveBeenCalledTimes(0);
-		done();
 	});
 
-	it("Logs error for wrong project type", async done => {
+	it("Logs error for wrong project type", async () => {
 		spyOn(Util, "error");
 		newCmd.template = jasmine.createSpyObj("TemplateManager", {
 			getFrameworkById: {},
@@ -85,10 +82,9 @@ describe("Unit - New command", () => {
 		expect(Util.error).toHaveBeenCalledWith(`Project type "js" not found in framework 'jq'`);
 		//no further attempts to get project:
 		expect(Util.log).toHaveBeenCalledTimes(0);
-		done();
 	});
 
-	it("Logs error for wrong project theme", async done => {
+	it("Logs error for wrong project theme", async () => {
 		spyOn(Util, "error");
 
 		const mockProjLib = {
@@ -110,10 +106,9 @@ describe("Unit - New command", () => {
 		//no further attempts to get project:
 		expect(Util.log).toHaveBeenCalledTimes(0);
 		expect(mockProjLib.getProject).toHaveBeenCalledTimes(0);
-		done();
 	});
 
-	it("Should start prompt session with missing arg", async done => {
+	it("Should start prompt session with missing arg", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue(null);
 
 		const mockProjLib = {};
@@ -128,10 +123,9 @@ describe("Unit - New command", () => {
 
 		await newCmd.execute({});
 		expect(promptSession.start).toHaveBeenCalled();
-		done();
 	});
 
-	it("Logs error for unavailable project", async done => {
+	it("Logs error for unavailable project", async () => {
 		spyOn(Util, "error");
 
 		const mockProjLib = {
@@ -154,10 +148,9 @@ describe("Unit - New command", () => {
 		expect(Util.error).toHaveBeenCalledWith("Project template not found");
 		//no other logs:
 		expect(Util.log).toHaveBeenCalledTimes(1);
-		done();
 	});
 
-	it("Generates default without project type", async done => {
+	it("Generates default without project type", async () => {
 		const mockDelimiters = { mockDelimiter: { start: "test", end: "test" }};
 		const mockTemplate = {
 			delimiters: mockDelimiters,
@@ -195,10 +188,9 @@ describe("Unit - New command", () => {
 		expect(process.chdir).toHaveBeenCalledWith("Test");
 		expect(process.chdir).toHaveBeenCalledWith("..");
 		expect(Util.log).toHaveBeenCalledWith(jasmine.stringMatching("Project Created"));
-		done();
 	});
 
-	it("Correctly generates passed project type", async done => {
+	it("Correctly generates passed project type", async () => {
 		const mockDelimiters = { mockDelimiter: { start: "test", end: "test" }};
 		const mockTemplate = {
 			delimiters: mockDelimiters,
@@ -234,10 +226,9 @@ describe("Unit - New command", () => {
 		expect(process.chdir).toHaveBeenCalledWith("..");
 		expect(Util.log).toHaveBeenCalledWith("Project Name: Test, framework jq, type type, theme ig");
 		expect(Util.log).toHaveBeenCalledWith(jasmine.stringMatching("Project Created"));
-		done();
 	});
 
-	it("Git initialization", async done => {
+	it("Git initialization", async () => {
 		const projectName = "projTitle";
 
 		const mockTemplate = {
@@ -267,10 +258,9 @@ describe("Unit - New command", () => {
 		expect(Util.log).toHaveBeenCalledWith(
 			jasmine.stringMatching("Git Initialized and Project '" + projectName + "' Committed")
 		);
-		done();
 	});
 
-	it("Skip Git initialization with command option", async done => {
+	it("Skip Git initialization with command option", async () => {
 		const projectName = "projTitle";
 
 		const mockTemplate = {
@@ -295,10 +285,9 @@ describe("Unit - New command", () => {
 		await newCmd.execute({ "name": projectName, "framework": "jq", "skip-git": true });
 
 		expect(Util.gitInit).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Skip Git initialization with configuration option", async done => {
+	it("Skip Git initialization with configuration option", async () => {
 		const projectName = "projTitle";
 
 		const mockTemplate = {
@@ -324,10 +313,9 @@ describe("Unit - New command", () => {
 		await newCmd.execute({ name: projectName, framework: "jq" });
 
 		expect(Util.gitInit).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Skip package install with command option", async done => {
+	it("Skip package install with command option", async () => {
 		const mockTemplate = {
 			generateConfig: { test: "test" },
 			templatePaths: ["test"]
@@ -351,6 +339,5 @@ describe("Unit - New command", () => {
 
 		expect(PackageManager.installPackages).not.toHaveBeenCalled();
 		expect(process.chdir).not.toHaveBeenCalled();
-		done();
 	});
 });

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { resetSpy } from "../helpers/utils";
 
 describe("Unit - Package Manager", () => {
-	it("ensureIgniteUISource - Should run through properly when install now is set to true", async done => {
+	it("ensureIgniteUISource - Should run through properly when install now is set to true", async () => {
 		const mockRequire = {
 			dependencies: {
 				"ignite-ui": "20.1"
@@ -78,9 +78,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.execSync).toHaveBeenCalledWith("npm config set @infragistics:registry trial");
 		expect(PackageManager.removePackage).toHaveBeenCalled();
 		expect(PackageManager.addPackage).toHaveBeenCalledWith(`@infragistics/ignite-ui-full@"20.1"`, true);
-		done();
 	});
-	it("ensureIgniteUISource - Should run through properly when install = true && package error", async done => {
+	it("ensureIgniteUISource - Should run through properly when install = true && package error", async () => {
 		class TestPackageManager extends PackageManager {
 			public static getPackageJSON(): any { }
 		}
@@ -157,9 +156,8 @@ describe("Unit - Package Manager", () => {
 		);
 		expect(Util.execSync).toHaveBeenCalledTimes(2);
 		expect(Util.execSync).toHaveBeenCalledWith(`npm whoami --registry=trial`, { stdio: "pipe", encoding: "utf8" });
-		done();
 	});
-	it("ensureIgniteUISource - Should run through properly when install now is set to false", async done => {
+	it("ensureIgniteUISource - Should run through properly when install now is set to false", async () => {
 		spyOn(Util, "log");
 		const mockTemplateMgr = jasmine.createSpyObj("mockTemplateMgr", {
 			getProjectLibrary: {
@@ -183,10 +181,9 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(
 			"Template(s) that require the full version of Ignite UI found in the project. " +
 			"You might be prompted for credentials on build to install it.", "yellow");
-		done();
 	});
 
-	it("ensureIgniteUISource - Should respect oss version when upgrading", async done => {
+	it("ensureIgniteUISource - Should respect oss version when upgrading", async () => {
 		class TestPackageManager extends PackageManager {
 			public static ensureRegistryUser(config: Config): boolean { return true; }
 			public static getPackageJSON(): any { }
@@ -243,10 +240,9 @@ describe("Unit - Package Manager", () => {
 			`npm install @infragistics/ignite-ui-full@">=0.1.0 <0.2.0" --quiet --save`,
 			jasmine.any(Object)
 		);
-		done();
 	});
 
-	it("Should run installPackages properly with error code", async done => {
+	it("Should run installPackages properly with error code", async () => {
 		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false
 		});
@@ -265,9 +261,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Example`);
 		expect(Util.execSync).toHaveBeenCalledWith(`npm install --quiet`, { stdio: ["inherit"], killSignal: "SIGINT" });
 		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ packagesInstalled: true });
-		done();
 	});
-	it("Should run installPackages properly without error code", async done => {
+	it("Should run installPackages properly without error code", async () => {
 		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false
 		});
@@ -281,9 +276,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Packages installed successfully`);
 		expect(Util.execSync).toHaveBeenCalledWith(`npm install --quiet`, { stdio: ["inherit"], killSignal: "SIGINT" });
 		expect(ProjectConfig.setConfig).toHaveBeenCalledWith({ packagesInstalled: true });
-		done();
 	});
-	it("Should exit on installPackages if child install is terminated", async done => {
+	it("Should exit on installPackages if child install is terminated", async () => {
 		spyOn(ProjectConfig, "localConfig").and.returnValue({
 			packagesInstalled: false,
 			skipAnalytic: true
@@ -302,9 +296,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.execSync).toHaveBeenCalledWith(`npm install --quiet`, { stdio: ["inherit"], killSignal: "SIGINT" });
 		expect(process.exit).toHaveBeenCalled();
 		expect(ProjectConfig.setConfig).toHaveBeenCalledTimes(0);
-		done();
 	});
-	it("Should run removePackage properly with error code", async done => {
+	it("Should run removePackage properly with error code", async () => {
 		spyOn(Util, "log");
 		spyOn(Util, "execSync").and.callFake(() => {
 			const err = new Error("Error");
@@ -318,9 +311,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.execSync).toHaveBeenCalledWith(
 			`npm uninstall example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" }
 		);
-		done();
 	});
-	it("Should run removePackage properly without error code", async done => {
+	it("Should run removePackage properly without error code", async () => {
 		spyOn(Util, "log");
 		spyOn(Util, "execSync").and.returnValue("");
 		PackageManager.removePackage("example-package");
@@ -328,9 +320,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Package example-package uninstalled successfully`);
 		expect(Util.execSync).toHaveBeenCalledWith(
 			`npm uninstall example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" });
-		done();
 	});
-	it("Should run addPackage properly with error code", async done => {
+	it("Should run addPackage properly with error code", async () => {
 		spyOn(Util, "log");
 		spyOn(Util, "execSync").and.callFake(() => {
 			const err = new Error("Error");
@@ -343,9 +334,8 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Error`);
 		expect(Util.execSync).toHaveBeenCalledWith(
 			`npm install example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" });
-		done();
 	});
-	it("Should run addPackage properly without error code", async done => {
+	it("Should run addPackage properly without error code", async () => {
 		spyOn(Util, "log");
 		spyOn(Util, "execSync").and.returnValue("");
 		PackageManager.addPackage("example-package", true);
@@ -353,10 +343,9 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Package example-package installed successfully`);
 		expect(Util.execSync).toHaveBeenCalledWith(
 			`npm install example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" });
-		done();
 	});
 
-	it("queuePackage should start package install", async done => {
+	it("queuePackage should start package install", async () => {
 		const mockRequire = {
 			dependencies: {}
 		};
@@ -378,10 +367,9 @@ describe("Unit - Package Manager", () => {
 		expect(cp.exec).toHaveBeenCalledTimes(1);
 		expect(cp.exec).toHaveBeenCalledWith(
 			`npm install test-pack --quiet --no-save`, {}, jasmine.any(Function));
-		done();
 	});
 
-	it("queuePackage should ignore existing package installs", async done => {
+	it("queuePackage should ignore existing package installs", async () => {
 		const mockRequire = {
 			dependencies: {
 				"test-pack": "20.1"
@@ -407,10 +395,9 @@ describe("Unit - Package Manager", () => {
 		PackageManager.queuePackage("test-pack2");
 		PackageManager.queuePackage("test-pack2");
 		expect(cp.exec).toHaveBeenCalledTimes(1);
-		done();
 	});
 
-	it("Should wait for and log queued package installs", async done => {
+	it("Should wait for and log queued package installs", async () => {
 		PackageManager["installQueue"] = []; //must reset from other tests
 		const mockRequire = {
 			dependencies: {}
@@ -451,6 +438,5 @@ describe("Unit - Package Manager", () => {
 		expect(Util.log).toHaveBeenCalledWith(`Waiting for additional packages to install`);
 		expect(Util.log).toHaveBeenCalledWith("Error installing package test-pack3");
 		expect(Util.log).toHaveBeenCalledWith("stderr");
-		done();
 	});
 });

--- a/spec/unit/quickstart-spec.ts
+++ b/spec/unit/quickstart-spec.ts
@@ -16,7 +16,7 @@ describe("Unit - Quickstart command", () => {
 		spyOn(process, "chdir");
 	});
 
-	it("Creates quickstart for the specified framework", async done => {
+	it("Creates quickstart for the specified framework", async () => {
 		spyOn(Util, "execSync");
 
 		await quickstartCmd.execute({ framework: "angular" });
@@ -29,10 +29,9 @@ describe("Unit - Quickstart command", () => {
 		expect(Util.log).toHaveBeenCalledWith("Quick Start!");
 		expect(Util.log).toHaveBeenCalledWith("angular-quickstart loaded");
 		expect(Util.log).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Logs error for wrong framework", async done => {
+	it("Logs error for wrong framework", async () => {
 		spyOn(Util, "error");
 
 		await quickstartCmd.execute({ framework: "lottery" });
@@ -40,10 +39,9 @@ describe("Unit - Quickstart command", () => {
 		expect(Util.error).toHaveBeenCalledWith("The framework is not supported!", "red");
 		expect(Util.log).toHaveBeenCalledWith("Quick Start!");
 		expect(Util.log).toHaveBeenCalledTimes(1);
-		done();
 	});
 
-	it("Creates default jquery quickstart when no framework is specified", async done => {
+	it("Creates default jquery quickstart when no framework is specified", async () => {
 		spyOn(Util, "execSync");
 		spyOn(liteServer, "server");
 		await quickstartCmd.execute({ framework: "jquery" });
@@ -55,10 +53,9 @@ describe("Unit - Quickstart command", () => {
 		expect(Util.log).toHaveBeenCalledWith("Quick Start!");
 		expect(Util.log).toHaveBeenCalledWith("jquery-quickstart loaded");
 		expect(Util.log).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Creates quickstart for React framework", async done => {
+	it("Creates quickstart for React framework", async () => {
 		spyOn(Util, "execSync");
 		spyOn(liteServer, "server");
 
@@ -72,6 +69,5 @@ describe("Unit - Quickstart command", () => {
 		expect(Util.log).toHaveBeenCalledWith("Quick Start!");
 		expect(Util.log).toHaveBeenCalledWith("react-quickstart loaded");
 		expect(Util.log).toHaveBeenCalledTimes(2);
-		done();
 	});
 });

--- a/spec/unit/start-spec.ts
+++ b/spec/unit/start-spec.ts
@@ -16,7 +16,7 @@ describe("Unit - start command", () => {
 		spyOn(buildCmd, "build");
 	});
 
-	it("Logs error when run outside project", async done => {
+	it("Logs error when run outside project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
 
 		await startCmd.execute({});
@@ -26,10 +26,9 @@ describe("Unit - start command", () => {
 			"red");
 		expect(Util.log).not.toHaveBeenCalled();
 		expect(Util.execSync).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Starts an Angular project", async done => {
+	it("Starts an Angular project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		// tslint:disable-next-line:no-object-literal-type-assertion
 		const config: Config = {
@@ -55,10 +54,9 @@ describe("Unit - start command", () => {
 		expect(Util.execSync).toHaveBeenCalledWith("npm start -- --port=1234", { stdio: "inherit", killSignal: "SIGINT" });
 
 		expect(Util.error).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Starts a React es6 project", async done => {
+	it("Starts a React es6 project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		// tslint:disable-next-line:no-object-literal-type-assertion
 		const config: Config = {
@@ -84,10 +82,9 @@ describe("Unit - start command", () => {
 			 expect(Util.execSync).toHaveBeenCalledWith("npm start -- --port=1234", { stdio: "inherit", killSignal: "SIGINT" });
 			*/
 		expect(Util.error).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Starts a React igr-es6 project", async done => {
+	it("Starts a React igr-es6 project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		// tslint:disable-next-line:no-object-literal-type-assertion
 		const config: Config = {
@@ -113,10 +110,9 @@ describe("Unit - start command", () => {
 		expect(Util.execSync).toHaveBeenCalledWith("npm start", { stdio: "inherit", killSignal: "SIGINT" });
 
 		expect(Util.error).not.toHaveBeenCalled();
-		done();
 	});
 
-	it("Starts a jQuery project", async done => {
+	it("Starts a jQuery project", async () => {
 		spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 		const bsConfig = { test: true };
 		const bsServMock = jasmine.createSpyObj("browserSync", ["init"]);
@@ -155,6 +151,5 @@ describe("Unit - start command", () => {
 		expect(bsServMock.init).toHaveBeenCalledWith({ test: true, port: 1234 });
 
 		expect(Util.error).not.toHaveBeenCalled();
-		done();
 	});
 });

--- a/spec/unit/test-spec.ts
+++ b/spec/unit/test-spec.ts
@@ -12,52 +12,42 @@ describe("Unit - Test command", () => {
 		spyOn(Util, "execSync");
 	});
 
-	it("Run tests for the current project", async done => {
+	it("Run tests for the current project", async () => {
 		await testCmd.test({skipAnalytics: true});
 		expect (Util.execSync).toHaveBeenCalledWith("npm test", { stdio: "inherit" });
-
-		done();
 	});
 
-	it("Run e2e tests for igx-ts Angular project type", async done => {
+	it("Run e2e tests for igx-ts Angular project type", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
 			projectType: "igx-ts"}});
 
 		await testCmd.test({e2e: true, skipAnalytics: true});
 		expect (Util.execSync).toHaveBeenCalledWith("npm run e2e", { stdio: "inherit" });
-
-		done();
 	});
 
-	it("e2e command for ig-ts Angular project type runs test command instead", async done => {
+	it("e2e command for ig-ts Angular project type runs test command instead", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "angular",
 			projectType: "ig-ts"}});
 
 		await testCmd.test({e2e: true, skipAnalytics: true});
 		expect (Util.execSync).toHaveBeenCalledWith("npm test", { stdio: "inherit" });
-
-		done();
 	});
 
-	it("e2e command for jQuery project runs test command instead", async done => {
+	it("e2e command for jQuery project runs test command instead", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "jquery"}});
 
 		await testCmd.test({e2e: true, skipAnalytics: true});
 		expect (Util.execSync).toHaveBeenCalledWith("npm test", { stdio: "inherit" });
-
-		done();
 	});
 
-	it("e2e command for React project runs test command instead", async done => {
+	it("e2e command for React project runs test command instead", async () => {
 		spyOn(ProjectConfig, "getConfig").and.returnValue({ project: {
 			framework: "react"}});
 
 		await testCmd.test({e2e: true, skipAnalytics: true});
 		expect (Util.execSync).toHaveBeenCalledWith("npm test", { stdio: "inherit" });
-
-		done();
 	});
 });

--- a/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptFileUpdate-spec.ts
@@ -8,7 +8,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 	});
 
 	describe("Initialization", () => {
-		it("Create with source file", async done => {
+		it("Create with source file", async () => {
 			class TestTsFileUpdate extends TypeScriptFileUpdate {
 				public initState() {
 					super.initState();
@@ -26,10 +26,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			expect(TypeScriptUtils.getFileSource).toHaveBeenCalledWith("/test/file");
 			expect(TestTsFileUpdate.prototype.initState).toHaveBeenCalled();
 			expect(TestTsFileUpdate.prototype.loadImportsMeta).toHaveBeenCalled();
-			done();
 		});
 
-		it("Properly initialize imports info", async done => {
+		it("Properly initialize imports info", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					import { Named } from "package"; //normal named import
@@ -60,7 +59,6 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				jasmine.objectContaining({ lastIndex: 7, modulePaths: ["package", "another/package", "./this/file"] }),
 				"Should collect all imports count and filter the editable paths"
 			);
-			done();
 		});
 	});
 
@@ -74,7 +72,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			}
 		}
 
-		it("Creates new imports", async done => {
+		it("Creates new imports", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					import { Named } from "package";
@@ -101,10 +99,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				)
 			);
 			expect(TestTsFileUpdate.prototype.formatFile).toHaveBeenCalled();
-			done();
 		});
 
-		it("Create and edit imports", async done => {
+		it("Create and edit imports", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					import { Named } from "package";
@@ -128,10 +125,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				)
 			);
 			expect(TestTsFileUpdate.prototype.formatFile).toHaveBeenCalled();
-			done();
 		});
 
-		it("Register imports for meta edits", async done => {
+		it("Register imports for meta edits", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", "", ts.ScriptTarget.Latest, true)
 			);
@@ -149,11 +145,10 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			//combine
 			tsUpdate.addNgModuleMeta({import: "import1", declare: ["declare1", "declare2"], provide: "prov1", from: "package"});
 			expect(requestImportSpy).toHaveBeenCalledWith(["import1", "declare1", "declare2", "prov1"], "package");
-			done();
 		});
 	});
 
-	it("Adds routes", async done => {
+	it("Adds routes", async () => {
 
 		let sourceCalls = 0;
 		spyOn(TypeScriptUtils, "getFileSource").and.callFake((input: string) => {
@@ -218,10 +213,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			)
 		);
 		expect(formatSpy).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Adds child routes", async done => {
+	it("Adds child routes", async () => {
 		let sourceCalls = 0;
 		spyOn(TypeScriptUtils, "getFileSource").and.callFake((input: string) => {
 			if (input === "route-module.ts") {
@@ -284,10 +278,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			)
 		);
 		expect(formatSpy).toHaveBeenCalledTimes(2);
-		done();
 	});
 
-	it("Adds declaration creates NgModule edit", async done => {
+	it("Adds declaration creates NgModule edit", async () => {
 		spyOn(TypeScriptUtils, "getFileSource").and.returnValues(
 			ts.createSourceFile("app.module.ts", "", ts.ScriptTarget.Latest, true),
 			{ getChildren: () => ["component1"] }
@@ -302,7 +295,6 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		expect(Util.relativePath).toHaveBeenCalledWith("app.module.ts", "relative/path", true, true);
 		expect(TypeScriptUtils.getClassName).toHaveBeenCalledWith(["component1"]);
 		expect(addMetaSpy).toHaveBeenCalledWith({ declare: "DeclareComponent", from: "./to/component" });
-		done();
 	});
 
 	describe("NgModule meta edits", () => {
@@ -315,7 +307,7 @@ describe("Unit - TypeScriptFileUpdate", () => {
 			}
 		}
 
-		it("Adds to imports and calls forRoot()", async done => {
+		it("Adds to imports and calls forRoot()", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					import { Named } from "package";
@@ -354,10 +346,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				].join("\\s*").replace(/([\[\]\(\)])/g, "\\$1"))
 			);
 			expect(TestTsFileUpdate.prototype.formatFile).toHaveBeenCalled();
-			done();
 		});
 
-		it("Adds to declarations/imports/provides", async done => {
+		it("Adds to declarations/imports/provides", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					import { Named } from "package";
@@ -404,10 +395,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				].join("\\s*").replace(/([\[\]\(\)])/g, "\\$1"))
 			);
 			expect(TestTsFileUpdate.prototype.formatFile).toHaveBeenCalled();
-			done();
 		});
 
-		it("Creates NgModule properties if not found", async done => {
+		it("Creates NgModule properties if not found", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", `
 					@NgModule({
@@ -445,10 +435,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				].join("\\s*").replace(/([\[\]\(\)])/g, "\\$1"))
 			);
 			expect(TestTsFileUpdate.prototype.formatFile).toHaveBeenCalled();
-			done();
 		});
 
-		it("Formats dependency properties", async done => {
+		it("Formats dependency properties", async () => {
 			spyOn(TypeScriptUtils, "getFileSource").and.returnValue(
 				ts.createSourceFile("/test/file", "", ts.ScriptTarget.Latest, true)
 			);
@@ -485,11 +474,10 @@ describe("Unit - TypeScriptFileUpdate", () => {
 				"./src/replace4/replace5.service"
 			);
 			// tslint:enable:object-literal-sort-keys
-			done();
 		});
 	});
 
-	it("Formats on finalize, preserves empty lines", async done => {
+	it("Formats on finalize, preserves empty lines", async () => {
 		// process is in root folder!
 		const unformattedSource = fs.readFileSync("spec/unit/ts-transform/unformatted.ts-template", "utf-8");
 		const formattedSource = fs.readFileSync("spec/unit/ts-transform/formatted.ts-template", "utf-8");
@@ -514,10 +502,9 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		// 	formattedSource
 		// );
 		expect(writeSpy.calls.mostRecent().args[1]).toEqual(formattedSource);
-		done();
 	});
 
-	it("Format applies editorconfig/tslint settings", async done => {
+	it("Format applies editorconfig/tslint settings", async () => {
 		class TestTsFileUpdate extends TypeScriptFileUpdate {
 			public getFormatting() {
 				return this.formatOptions;
@@ -589,7 +576,6 @@ describe("Unit - TypeScriptFileUpdate", () => {
 		expect(tsUpdate.getFormatting().indentSize).toEqual(2);
 		expect(tsUpdate.getFormatting().spaces).toEqual(false);
 
-		done();
 	});
 
 });

--- a/spec/unit/ts-transform/TypeScriptUtils-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptUtils-spec.ts
@@ -60,7 +60,7 @@ describe("Unit - TypeScriptUtils", () => {
 				const source: ts.SourceFile = {} as any;
 				printerSpy.and.returnValue(printer);
 
-				const result = TypeScriptUtils.saveFile(`test/file${key}.ts`, source);
+				TypeScriptUtils.saveFile(`test/file${key}.ts`, source as any);
 				expect(printer.printFile).toHaveBeenCalledWith(source);
 				expect(fs.writeFileSync).toHaveBeenCalledWith(`test/file${key}.ts`, expectedText.join(newLines[key]));
 			}
@@ -73,15 +73,15 @@ describe("Unit - TypeScriptUtils", () => {
 		it("Creates correct identifier or method call", async done => {
 			const printer = ts.createPrinter();
 			const identifier = TypeScriptUtils.createIdentifier("Test");
-			expect(identifier.kind).toBe(ts.SyntaxKind.Identifier);
-			const identifierText = printer.printNode(ts.EmitHint.Unspecified, identifier, null);
+			expect(identifier.kind as ts.SyntaxKind.Identifier).toBe(ts.SyntaxKind.Identifier);
+			const identifierText = printer.printNode(ts.EmitHint.Unspecified, (identifier as unknown) as ts.Node, null);
 			expect(identifierText).toBe("Test");
 
 			const identifierCall = TypeScriptUtils.createIdentifier("Test", "method");
-			expect(identifierCall.kind).toBe(ts.SyntaxKind.CallExpression);
+			expect(identifierCall.kind as ts.SyntaxKind).toBe(ts.SyntaxKind.CallExpression);
 			const identifierCallText = printer.printNode(
 				ts.EmitHint.Unspecified,
-				identifierCall,
+				(identifierCall as unknown) as ts.Node,
 				ts.createSourceFile("", "", ts.ScriptTarget.Latest)
 			);
 			expect(identifierCallText).toBe("Test.method()");
@@ -91,15 +91,15 @@ describe("Unit - TypeScriptUtils", () => {
 		it("Creates correct import node", async done => {
 			const printer = ts.createPrinter();
 			const nameImport = TypeScriptUtils.createIdentifierImport(["Name"], "package");
-			expect(nameImport.kind).toBe(ts.SyntaxKind.ImportDeclaration);
-			expect((nameImport.moduleSpecifier as ts.StringLiteral).text).toBe("package");
+			expect(nameImport.kind as ts.SyntaxKind).toBe(ts.SyntaxKind.ImportDeclaration);
+			expect(((nameImport.moduleSpecifier as unknown) as ts.StringLiteral).text).toBe("package");
 			expect(nameImport.importClause.namedBindings).toBeDefined();
-			expect(printer.printNode(ts.EmitHint.Unspecified, nameImport, null)).toBe(`import { Name } from "package";`);
+			expect(printer.printNode(ts.EmitHint.Unspecified, (nameImport as unknown) as ts.Node, null)).toBe(`import { Name } from "package";`);
 
 			const namesImport = TypeScriptUtils.createIdentifierImport(["Test1", "Test2"], "@namespace/package");
-			expect((namesImport.moduleSpecifier as ts.StringLiteral).text).toBe("@namespace/package");
+			expect(((namesImport.moduleSpecifier as unknown) as ts.StringLiteral).text).toBe("@namespace/package");
 			expect(namesImport.importClause.namedBindings).toBeDefined();
-			const namesImportText = printer.printNode(ts.EmitHint.Unspecified, namesImport, null);
+			const namesImportText = printer.printNode(ts.EmitHint.Unspecified, (namesImport as unknown) as ts.Node, null);
 			expect(namesImportText).toBe(`import { Test1, Test2 } from "@namespace/package";`);
 			done();
 		});
@@ -109,7 +109,7 @@ describe("Unit - TypeScriptUtils", () => {
 		const classSource = ts.createSourceFile("",
 			`export class TestClass {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(classSource.getChildren())).toBe("TestClass");
+		expect(TypeScriptUtils.getClassName(classSource.getChildren() as any)).toBe("TestClass");
 
 		const classDecoratorSource = ts.createSourceFile("",
 			`@Component({
@@ -117,13 +117,13 @@ describe("Unit - TypeScriptUtils", () => {
 			})
 			export class TestDecoratorClass {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(classDecoratorSource.getChildren())).toBe("TestDecoratorClass");
+		expect(TypeScriptUtils.getClassName(classDecoratorSource.getChildren() as any)).toBe("TestDecoratorClass");
 
 		const multipleClassSource = ts.createSourceFile("",
 			`export class TestDecoratorClass1 {}
 			export class TestDecoratorClass2 {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(multipleClassSource.getChildren())).toBe("TestDecoratorClass1");
+		expect(TypeScriptUtils.getClassName(multipleClassSource.getChildren() as any)).toBe("TestDecoratorClass1");
 
 		const noExportClassSource = ts.createSourceFile("",
 			`function name() {
@@ -131,7 +131,7 @@ describe("Unit - TypeScriptUtils", () => {
 			}
 			export class TestDecoratorClass2 {}`,
 			ts.ScriptTarget.Latest, true);
-		expect(TypeScriptUtils.getClassName(noExportClassSource.getChildren())).toBe("TestDecoratorClass2");
+		expect(TypeScriptUtils.getClassName(noExportClassSource.getChildren() as any)).toBe("TestDecoratorClass2");
 		done();
 	});
 });

--- a/spec/unit/ts-transform/TypeScriptUtils-spec.ts
+++ b/spec/unit/ts-transform/TypeScriptUtils-spec.ts
@@ -10,7 +10,7 @@ describe("Unit - TypeScriptUtils", () => {
 			CRLF: "\r\n",
 			LF: "\n"
 		};
-		it("Reads source file and adds new line ([CR]LF) placeholders", async done => {
+		it("Reads source file and adds new line ([CR]LF) placeholders", async () => {
 			const sourceText = [
 				`import * as fs from "fs";`,
 				``, //new line
@@ -36,10 +36,9 @@ describe("Unit - TypeScriptUtils", () => {
 				);
 			}
 
-			done();
 		});
 
-		it("Save source file and removes ([CR]LF) placeholders", async done => {
+		it("Save source file and removes ([CR]LF) placeholders", async () => {
 			const sourceText = [
 				`import * as fs from "fs";`,
 				TypeScriptUtils.newLinePlaceHolder,
@@ -64,13 +63,12 @@ describe("Unit - TypeScriptUtils", () => {
 				expect(printer.printFile).toHaveBeenCalledWith(source);
 				expect(fs.writeFileSync).toHaveBeenCalledWith(`test/file${key}.ts`, expectedText.join(newLines[key]));
 			}
-			done();
 		});
 	});
 
 	describe("Node creation", () => {
 
-		it("Creates correct identifier or method call", async done => {
+		it("Creates correct identifier or method call", async () => {
 			const printer = ts.createPrinter();
 			const identifier = TypeScriptUtils.createIdentifier("Test");
 			expect(identifier.kind as ts.SyntaxKind.Identifier).toBe(ts.SyntaxKind.Identifier);
@@ -85,10 +83,9 @@ describe("Unit - TypeScriptUtils", () => {
 				ts.createSourceFile("", "", ts.ScriptTarget.Latest)
 			);
 			expect(identifierCallText).toBe("Test.method()");
-			done();
 		});
 
-		it("Creates correct import node", async done => {
+		it("Creates correct import node", async () => {
 			const printer = ts.createPrinter();
 			const nameImport = TypeScriptUtils.createIdentifierImport(["Name"], "package");
 			expect(nameImport.kind as ts.SyntaxKind).toBe(ts.SyntaxKind.ImportDeclaration);
@@ -101,11 +98,10 @@ describe("Unit - TypeScriptUtils", () => {
 			expect(namesImport.importClause.namedBindings).toBeDefined();
 			const namesImportText = printer.printNode(ts.EmitHint.Unspecified, (namesImport as unknown) as ts.Node, null);
 			expect(namesImportText).toBe(`import { Test1, Test2 } from "@namespace/package";`);
-			done();
 		});
 	});
 
-	it("Gets class name", async done => {
+	it("Gets class name", async () => {
 		const classSource = ts.createSourceFile("",
 			`export class TestClass {}`,
 			ts.ScriptTarget.Latest, true);
@@ -132,6 +128,5 @@ describe("Unit - TypeScriptUtils", () => {
 			export class TestDecoratorClass2 {}`,
 			ts.ScriptTarget.Latest, true);
 		expect(TypeScriptUtils.getClassName(noExportClassSource.getChildren() as any)).toBe("TestDecoratorClass2");
-		done();
 	});
 });

--- a/spec/unit/upgrade-spec.ts
+++ b/spec/unit/upgrade-spec.ts
@@ -16,7 +16,7 @@ describe("Unit - Upgrade command", () => {
 		spyOn(PackageManager, "installPackages");
 	});
 
-	it("Upgrade an Ignite UI for Angular project", async done => {
+	it("Upgrade an Ignite UI for Angular project", async () => {
 		// tslint:disable-next-line: no-object-literal-type-assertion
 		const config: Config = {
 			project: {
@@ -56,11 +56,9 @@ describe("Unit - Upgrade command", () => {
 		await upgradeCmd.execute({ skipInstall: false });
 		expect(mockProject.upgradeIgniteUIPackages).toHaveBeenCalledTimes(3);
 		expect(Util.execSync).toHaveBeenCalledWith("npm install --quiet");
-
-		done();
 	});
 
-	it("Logs error for not supported framework", async done => {
+	it("Logs error for not supported framework", async () => {
 		// tslint:disable-next-line: no-object-literal-type-assertion
 		const config: Config = {
 			project: {
@@ -71,6 +69,5 @@ describe("Unit - Upgrade command", () => {
 
 		await upgradeCmd.execute({});
 		expect(Util.log).toHaveBeenCalledTimes(1);
-		done();
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
 	"compilerOptions": {
 		"baseUrl": ".",
-		"target": "es6",
-		"module": "commonjs",
+		"target": "ES6",
+		"module": "CommonJS",
+		"esModuleInterop": true,
+		"moduleResolution": "Node16",
 		"sourceMap": true,
 		"paths": {
 			"@igniteui/cli-core": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,7 +2951,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz"
   integrity "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs= sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig=="
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   dependencies:
@@ -3690,6 +3690,11 @@ istanbul-reports@^2.1.1:
   dependencies:
     html-escaper "^2.0.0"
 
+jasmine-core@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.4.0.tgz#848fe45c1839cacaf1f2429d400d1d4f85d2856a"
+  integrity sha512-+l482uImx5BVd6brJYlaHe2UwfKoZBqQfNp20ZmdNfsjGFTemGfqHLsXjKEW23w9R/m8WYeFc9JmIgjj6dUtAA==
+
 jasmine-core@~3.5.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz"
@@ -3712,6 +3717,14 @@ jasmine@3.5.0:
   dependencies:
     glob "^7.1.4"
     jasmine-core "~3.5.0"
+
+jasmine@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-4.4.0.tgz#e3e359723d9679993b70de3e0441517c154b9647"
+  integrity sha512-xrbOyYkkCvgduNw7CKktDtNb+BwwBv/zvQeHpTkbxqQ37AJL5V4sY3jHoMIJPP/hTc3QxLVwOyxc87AqA+kw5g==
+  dependencies:
+    glob "^7.1.6"
+    jasmine-core "^4.4.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -6305,6 +6318,11 @@ typescript@^3.5.3:
 typescript@^4.6.2, typescript@~4.7.2:
   version "4.7.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz"
+
+typescript@^4.9.0-dev.20220914:
+  version "4.9.0-dev.20220914"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.0-dev.20220914.tgz#16b3253d784cb0739dba362cc55adeebd9c8fd50"
+  integrity sha512-U1GcTQISGDyNlwr/OUTQVKFGMjL5eYrzT4nTptRn6lcaiRwO0+zmdHD3FMf6ZdiV5wZMMU706GH08EgiBufIqw==
 
 typescript@~4.5.2:
   version "4.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1005,7 +1005,7 @@
   version "1.2.2"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^8.0.31", "@types/node@^8.10.0":
+"@types/node@*", "@types/node@>= 8", "@types/node@^8.0.31":
   version "8.10.66"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz"
 
@@ -1016,6 +1016,11 @@
 "@types/node@^12.11.1":
   version "12.20.52"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz"
+
+"@types/node@^14.18.27":
+  version "14.18.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.28.tgz#ddb82da2fff476a8e827e8773c84c19d9c235278"
+  integrity sha512-CK2fnrQlIgKlCV3N2kM+Gznb5USlwA1KFX3rJVHmgVk6NJxFPuQ86pAcvKnu37IA4BGlSRz7sEE1lHL1aLZ/eQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1375,7 +1380,7 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
 
-axios@0.21.4:
+axios@0.21.4, axios@~0.21.4:
   version "0.21.4"
   resolved "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"
   dependencies:
@@ -3386,6 +3391,13 @@ is-ci@^2.0.0:
 is-core-module@^2.5.0, is-core-module@^2.8.1:
   version "2.9.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz"
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -5414,6 +5426,15 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.6.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@~1.22.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resp-modifier@6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz"
@@ -5493,7 +5514,7 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1, semver@~5.7.1:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
 
@@ -6251,7 +6272,7 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz"
 
-type-fest@^0.3.0:
+type-fest@^0.3.0, type-fest@~0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz"
 


### PR DESCRIPTION
This PR updates the CLI to use [TypeScript modules](https://www.typescriptlang.org/docs/handbook/modules.html). We need this update as in https://github.com/IgniteUI/igniteui-cli/pull/1057 we are trying to use dynamic imports in `TS` to get to logic that's been delegated to whoever is implementing a given migration. These changes cause build errors and a bunch of tests to go haywire which is expected as we are essentially changing the way we export/import modules across the whole of the CLI.