### PR TITLE
Remove height: 100% from body

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/styles.css
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/styles.css
@@ -2,8 +2,3 @@ body {
   background: hsla(var(--igc-surface-500, 0 0% 100%));
   color: var(--igc-surface-500-contrast, black);
 }
-
-html,
-body {
-  height: 100%;
-}


### PR DESCRIPTION
height: 100% is not needed in generated CodeGen WC projects but it breaks some layouts (scrollbars are displayed in Team Collaboration app, for example).

