### PR TITLE
Add .npmrc to wc proj template

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/.npmrc
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/.npmrc
@@ -1,0 +1,2 @@
+@infragistics:registry=https://packages.infragistics.com/npm/js-licensed/
+//packages.infragistics.com/npm/js-licensed/:always-auth=true


### PR DESCRIPTION
This PR adds `.npmrc` file to webcomponents' base project template.