### PR TITLE
chore(igx): add explicitely igniteui-theming package

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/package.json
@@ -20,6 +20,7 @@
     "@angular/router": "~15.2.0",
     "hammerjs": "^2.0.8",
     "igniteui-angular": "~15.1.0",
+    "igniteui-theming": "~1.4.4",
     "minireset.css": "~0.0.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/packages/igx-templates/igx-ts/projects/side-nav-auth/files/package.json
+++ b/packages/igx-templates/igx-ts/projects/side-nav-auth/files/package.json
@@ -21,6 +21,7 @@
     "angular-auth-oidc-client": "^9.0.3",
     "hammerjs": "^2.0.8",
     "igniteui-angular": "~15.1.0",
+    "igniteui-theming": "~1.4.4",
     "minireset.css": "~0.0.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.4.0",


### PR DESCRIPTION
From time to time `igniteui-theming`, which is a peer dependency of `igniteui-angular`, is not installed on a root level in the generated project and the following error is thrown:

```console
./src/styles.scss - Error: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Can't find stylesheet to import.
  ╷
1 │ @use 'igniteui-theming/sass/color/functions' as *;
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  node_modules\@infragistics\igniteui-angular\lib\core\styles\base\_mixins.scss 1:1  @forward
  node_modules\@infragistics\igniteui-angular\lib\core\styles\base\_index.scss 2:1   @use
  node_modules\@infragistics\igniteui-angular\lib\core\styles\themes\_core.scss 6:1  @forward
  @infragistics\igniteui-angular\_index.scss 1:1                                     @use
  src\styles.scss 5:1                                                                root stylesheet
```

even though the following configuration is available in the `angular.json`:

```json
"stylePreprocessorOptions": {
  "includePaths": ["node_modules"]
}
```

