### PR TITLE
Fix memory allocation issue during build of webComponent app that uses igc-category-chart

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/files/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
-    "build": "rimraf dist && tsc && rollup -c rollup.config.mjs",
+    "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-path .gitignore",
     "test": "tsc --project tsconfig.test.json && wtr"


### PR DESCRIPTION
When building our webComponent app, which uses charts, there is a critical memory allocation problem with rollup under Linux. The build process would fail with the error message: "FATAL ERROR: Reached heap limit. Allocation failed - JavaScript heap out of memory." This issue was unique to Linux because the default Node.js heap size is limited to 2GB, while the build succeeds under Windows, where the default Node.js heap size is 4GB.

Closes # .  

Additional information related to this pull request:

