### PR TITLE
Adding rxjs dependency in default WebComponents template

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
@@ -23,6 +23,7 @@
     "@vaadin/router": "^1.7.4",
     "lit": "^2.6.1",
     "typescript": "^4.9.4",
+    "rxjs": "~7.8.0",
     "igniteui-webcomponents": "~4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

