### PR TITLE
chore(migrations): remove ng update package groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [12.0.6](https://github.com/IgniteUI/igniteui-cli/compare/v12.0.5...v12.0.6) (2023-10-02)
+
+## What's Changed
+
+* remove ng update package groups by @lipata in https://github.com/IgniteUI/igniteui-cli/pull/1151
+
 # [12.0.5](https://github.com/IgniteUI/igniteui-cli/compare/v12.0.4...v12.0.5) (2023-07-18)
 
 ## What's Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "12.0.6-beta.2",
+  "version": "12.0.6",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~16.0.1206-beta.2",
-    "@igniteui/cli-core": "~12.0.6-beta.2",
+    "@igniteui/angular-templates": "~16.0.1206",
+    "@igniteui/cli-core": "~12.0.6",
     "chalk": "^2.3.2",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "12.0.5",
+  "version": "12.0.6-beta.2",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~16.0.1205",
-    "@igniteui/cli-core": "~12.0.5",
+    "@igniteui/angular-templates": "~16.0.1206-beta.2",
+    "@igniteui/cli-core": "~12.0.6-beta.2",
     "chalk": "^2.3.2",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -111,13 +111,6 @@
     "typescript-json-schema": "^0.42.0"
   },
   "ng-update": {
-    "migrations": "./migrations/migration-collection.json",
-    "packageGroup": [
-      "igniteui-cli",
-      "igniteui-angular",
-      "@infragistics/igniteui-angular",
-      "igniteui-angular-charts",
-      "@igniteui/angular-templates"
-    ]
+    "migrations": "./migrations/migration-collection.json"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "12.0.5",
+  "version": "12.0.6-beta.2",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "12.0.6-beta.2",
+  "version": "12.0.6",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "16.0.1205",
+  "version": "16.0.1206-beta.2",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~12.0.5",
+    "@igniteui/cli-core": "~12.0.6-beta.2",
     "typescript": "~4.7.2"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "16.0.1206-beta.2",
+  "version": "16.0.1206",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~12.0.6-beta.2",
+    "@igniteui/cli-core": "~12.0.6",
     "typescript": "~4.7.2"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -32,13 +32,6 @@
     "typescript": "~4.5.2"
   },
   "ng-update": {
-    "migrations": "./src/migrations/migration-collection.json",
-    "packageGroup": [
-      "@igniteui/angular-schematics",
-      "igniteui-angular",
-      "@infragistics/igniteui-angular",
-      "igniteui-angular-charts",
-      "@igniteui/angular-templates"
-    ]
+    "migrations": "./src/migrations/migration-collection.json"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "16.0.1205",
+  "version": "16.0.1206-beta.2",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "~14.0.0",
     "@angular-devkit/schematics": "~14.0.0",
-    "@igniteui/angular-templates": "~16.0.1205",
-    "@igniteui/cli-core": "~12.0.5",
+    "@igniteui/angular-templates": "~16.0.1206-beta.2",
+    "@igniteui/cli-core": "~12.0.6-beta.2",
     "@schematics/angular": "~14.0.0",
     "rxjs": "^6.6.3"
   },

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "16.0.1206-beta.2",
+  "version": "16.0.1206",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "~14.0.0",
     "@angular-devkit/schematics": "~14.0.0",
-    "@igniteui/angular-templates": "~16.0.1206-beta.2",
-    "@igniteui/cli-core": "~12.0.6-beta.2",
+    "@igniteui/angular-templates": "~16.0.1206",
+    "@igniteui/cli-core": "~12.0.6",
     "@schematics/angular": "~14.0.0",
     "rxjs": "^6.6.3"
   },


### PR DESCRIPTION
Remove ng update package groups, because they contain product libraries, `igniteui-angular` and its licensed version, which will lead to the latter being omitted in the `ng update` list.

Along with the [following change](https://github.com/IgniteUI/igniteui-angular/pull/13512) in the `igniteui-angular`, when the latter is updated then `igniteui-angular-i18n` will also be updated and when `ng update` is invoked then `igniteui-angular` will be visible as a name of the group.

