### PR TITLE
In lowerDashed do not add dash before numbers - 13.0.x

### DIFF
--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -240,7 +240,7 @@ export class Util {
 	 * Add dash on the place of empty spaces and between lower and upper case letters.
 	 */
 	public static lowerDashed(text: string) {
-		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}]))", "gu");
+		const regex = new RegExp("[\\s]+|([\\p{Ll}\\p{Nd}](?=[\\p{Lu}]))", "gu");
 		const result = text.trim()
 				.replace(regex, "$1-")
 				.toLowerCase();

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -237,9 +237,10 @@ export class Util {
 
 	/**
 	 * lower-dashed string
+	 * Add dash on the place of empty spaces and between lower and upper case letters.
 	 */
 	public static lowerDashed(text: string) {
-		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}\\p{Nd}]))", "gu");
+		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}]))", "gu");
 		const result = text.trim()
 				.replace(regex, "$1-")
 				.toLowerCase();


### PR DESCRIPTION
Closes #1171 

Do not add dash before numbers. `lowerDashed` will now add dash between lower-case letter or number and upper-case letter as well as on the place of the empty spaces.