### PR TITLE
In lowerDashed do not add dash before numbers - 12.0.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "12.0.8-beta.0",
+  "version": "12.0.8-beta.1",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~16.0.1208-beta.0",
-    "@igniteui/cli-core": "~12.0.8-beta.0",
+    "@igniteui/angular-templates": "~16.0.1208-beta.1",
+    "@igniteui/cli-core": "~12.0.8-beta.1",
     "chalk": "^2.3.2",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "12.0.7",
+  "version": "12.0.8-beta.0",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~16.0.1207",
-    "@igniteui/cli-core": "~12.0.7",
+    "@igniteui/angular-templates": "~16.0.1208-beta.0",
+    "@igniteui/cli-core": "~12.0.8-beta.0",
     "chalk": "^2.3.2",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "12.0.7",
+  "version": "12.0.8-beta.0",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "12.0.8-beta.0",
+  "version": "12.0.8-beta.1",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -240,7 +240,7 @@ export class Util {
 	 * Add dash on the place of empty spaces and between lower and upper case letters.
 	 */
 	public static lowerDashed(text: string) {
-		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}]))", "gu");
+		const regex = new RegExp("[\\s]+|([\\p{Ll}\\p{Nd}](?=[\\p{Lu}]))", "gu");
 		const result = text.trim()
 				.replace(regex, "$1-")
 				.toLowerCase();

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -237,9 +237,10 @@ export class Util {
 
 	/**
 	 * lower-dashed string
+	 * Add dash on the place of empty spaces and between lower and upper case letters.
 	 */
 	public static lowerDashed(text: string) {
-		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}\\p{Nd}]))", "gu");
+		const regex = new RegExp("[\\s]+|([\\p{Ll}](?=[\\p{Lu}]))", "gu");
 		const result = text.trim()
 				.replace(regex, "$1-")
 				.toLowerCase();

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "16.0.1208-beta.0",
+  "version": "16.0.1208-beta.1",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~12.0.8-beta.0",
+    "@igniteui/cli-core": "~12.0.8-beta.1",
     "typescript": "~4.7.2"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "16.0.1207",
+  "version": "16.0.1208-beta.0",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~12.0.7",
+    "@igniteui/cli-core": "~12.0.8-beta.0",
     "typescript": "~4.7.2"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "16.0.1208-beta.0",
+  "version": "16.0.1208-beta.1",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "~14.0.0",
     "@angular-devkit/schematics": "~14.0.0",
-    "@igniteui/angular-templates": "~16.0.1208-beta.0",
-    "@igniteui/cli-core": "~12.0.8-beta.0",
+    "@igniteui/angular-templates": "~16.0.1208-beta.1",
+    "@igniteui/cli-core": "~12.0.8-beta.1",
     "@schematics/angular": "~14.0.0",
     "rxjs": "^6.6.3"
   },

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "16.0.1207",
+  "version": "16.0.1208-beta.0",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "~14.0.0",
     "@angular-devkit/schematics": "~14.0.0",
-    "@igniteui/angular-templates": "~16.0.1207",
-    "@igniteui/cli-core": "~12.0.7",
+    "@igniteui/angular-templates": "~16.0.1208-beta.0",
+    "@igniteui/cli-core": "~12.0.8-beta.0",
     "@schematics/angular": "~14.0.0",
     "rxjs": "^6.6.3"
   },


### PR DESCRIPTION
Closes #1171 

Do not add dash before numbers. `lowerDashed` will now add dash between lower-case letter or number and upper-case letter as well as on the place of the empty spaces.