### PR TITLE
Resolve proj lib by  type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [13.1.2](https://github.com/IgniteUI/igniteui-cli/compare/v13.1.1...v13.1.2) (2024-01-02)
+
+## What's Changed
+
+* Resolve proj lib by type by @jackofdiamond5 in https://github.com/IgniteUI/igniteui-cli/pull/1188
+
+**Full Changelog**: https://github.com/IgniteUI/igniteui-cli/compare/v13.1.1...v13.1.2
+
 # [13.1.1](https://github.com/IgniteUI/igniteui-cli/compare/v13.1.0...v13.1.1) (2023-12-14)
 
 ## What's Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~17.1.1311",
-    "@igniteui/cli-core": "~13.1.1",
+    "@igniteui/angular-templates": "~17.1.1312",
+    "@igniteui/cli-core": "~13.1.2",
     "chalk": "^2.3.2",
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "13.1.1",
+  "version": "13.1.2",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/package.json
@@ -45,7 +45,7 @@
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.0.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.2.2"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "17.1.1311",
+  "version": "17.1.1312",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~13.1.1",
+    "@igniteui/cli-core": "~13.1.2",
     "typescript": "~4.7.2"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "17.1.1311",
+  "version": "17.1.1312",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "~14.0.0",
     "@angular-devkit/schematics": "~14.0.0",
-    "@igniteui/angular-templates": "~17.1.1311",
-    "@igniteui/cli-core": "~13.1.1",
+    "@igniteui/angular-templates": "~17.1.1312",
+    "@igniteui/cli-core": "~13.1.2",
     "@schematics/angular": "~14.0.0",
     "rxjs": "^6.6.3"
   },

--- a/packages/ng-schematics/src/ng-new/index.ts
+++ b/packages/ng-schematics/src/ng-new/index.ts
@@ -60,7 +60,7 @@ export function newProject(options: OptionsSchema): Rule {
 						throw new SchematicsException(`Folder "${options.name}" already exists!`);
 					}
 					const framework = templateManager.getFrameworkByName("angular");
-					projLibrary = await prompt.getProjectLibrary(framework);
+					projLibrary = await prompt.getProjectLibraryByType(framework, options.type);
 
 					if (!options.name || !prompt.nameIsValid(options.name)) {
 						options.name = await prompt.getUserInput({

--- a/packages/ng-schematics/src/ng-new/index_spec.ts
+++ b/packages/ng-schematics/src/ng-new/index_spec.ts
@@ -56,7 +56,7 @@ describe("Schematics ng-new", () => {
 			return currentTree;
 		});
 
-		runner.runSchematicAsync("ng-new", { version: "8.0.3", type: "igx-ts-legacy" }, myTree)
+		runner.runSchematicAsync("ng-new", { version: "8.0.3" }, myTree)
 		.pipe(take(1))
 		.subscribe((e: UnitTestTree) => {
 			for (const mockFunc of Object.entries(mockSession)) {

--- a/packages/ng-schematics/src/ng-new/index_spec.ts
+++ b/packages/ng-schematics/src/ng-new/index_spec.ts
@@ -33,7 +33,7 @@ describe("Schematics ng-new", () => {
 		const mockSession = {
 			chooseActionLoop: spyOn(SchematicsPromptSession.prototype, "chooseActionLoop")
 				.and.returnValue(Promise.resolve(true)),
-			getProjectLibrary: spyOn(SchematicsPromptSession.prototype, "getProjectLibrary")
+			getProjectLibraryByType: spyOn(SchematicsPromptSession.prototype, "getProjectLibraryByType")
 				.and.returnValue((Promise.resolve(mockLibrary))),
 			getProjectTemplate: spyOn(SchematicsPromptSession.prototype, "getProjectTemplate")
 				.and.returnValue(Promise.resolve(mockProject)),
@@ -56,7 +56,7 @@ describe("Schematics ng-new", () => {
 			return currentTree;
 		});
 
-		runner.runSchematicAsync("ng-new", { version: "8.0.3" }, myTree)
+		runner.runSchematicAsync("ng-new", { version: "8.0.3", type: "igx-ts-legacy" }, myTree)
 		.pipe(take(1))
 		.subscribe((e: UnitTestTree) => {
 			for (const mockFunc of Object.entries(mockSession)) {
@@ -112,7 +112,7 @@ describe("Schematics ng-new", () => {
 		};
 
 		const mockSession = {
-			getProjectLibrary: spyOn(SchematicsPromptSession.prototype, "getProjectLibrary")
+			getProjectLibraryByType: spyOn(SchematicsPromptSession.prototype, "getProjectLibraryByType")
 			.and.returnValue((Promise.resolve(mockLibrary)))
 		};
 

--- a/packages/ng-schematics/src/ng-new/schema.json
+++ b/packages/ng-schematics/src/ng-new/schema.json
@@ -40,6 +40,12 @@
     "template": {
       "description": "Project template.",
       "type": "string"
+    },
+    "type": {
+        "description": "Project type.",
+        "type": "string",
+        "alias": "t",
+		"default": "igx-ts"
     }
   },
   "required": [

--- a/packages/ng-schematics/src/ng-new/schema.json
+++ b/packages/ng-schematics/src/ng-new/schema.json
@@ -45,7 +45,7 @@
         "description": "Project type.",
         "type": "string",
         "alias": "t",
-		"default": "igx-ts"
+        "default": "igx-ts"
     }
   },
   "required": [

--- a/packages/ng-schematics/src/ng-new/schema.ts
+++ b/packages/ng-schematics/src/ng-new/schema.ts
@@ -18,4 +18,6 @@ export abstract class OptionsSchema {
 	public theme: string;
 
 	public template: string;
+
+	public type: string;
 }

--- a/packages/ng-schematics/src/prompt/SchematicsPromptSession.ts
+++ b/packages/ng-schematics/src/prompt/SchematicsPromptSession.ts
@@ -35,6 +35,12 @@ export class SchematicsPromptSession extends BasePromptSession {
 		return super.getProjectLibrary(framework);
 	}
 
+	public async getProjectLibraryByType(framework: Framework, type: string): Promise<ProjectLibrary> {
+		type = type === "igx-ts" || type === "igx-ts-legacy" ? type : "igx-ts";
+		framework.projectLibraries = [framework.projectLibraries.find(lib => lib.projectType === type)!];
+		return super.getProjectLibrary(framework);
+	}
+
 	public async getProjectTemplate(projectLibrary: ProjectLibrary): Promise<ProjectTemplate> {
 		return super.getProjectTemplate(projectLibrary);
 	}


### PR DESCRIPTION
With the introduction of standalone components in our CLI the ng-schematics need to be able to resolve the type of the project when calling `ng new`. So far, we've only had one project library for angular - `igx-ts`, though now we have two - `igx-ts` & `igx-ts-legacy`. This creates the need to add the `--type` flag which will default to `igx-ts` and when calling `ng new` this will allow our schematics to not initiate a prompt session.