### PR TITLE
Provide http client

### DIFF
--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/ignite-ui-cli.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/ignite-ui-cli.json
@@ -3,7 +3,7 @@
   "project": {
     "defaultPort": 4200,
     "framework": "angular",
-    "projectType": "igx-ts",
+    "projectType": "igx-ts-legacy",
     "projectTemplate": "<%=projectTemplate%>",
     "theme": "<%=theme%>",
     "themePath": "<%=themePath%>",

--- a/packages/igx-templates/igx-ts/projects/_base/files/src/app/app.config.ts
+++ b/packages/igx-templates/igx-ts/projects/_base/files/src/app/app.config.ts
@@ -1,15 +1,17 @@
 import { ApplicationConfig, importProvidersFrom } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
-import { BrowserModule, HammerModule } from '@angular/platform-browser';
+import { HammerModule } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withComponentInputBinding()),
-    importProvidersFrom(BrowserModule, HammerModule),
-    provideAnimations()
+    importProvidersFrom(HammerModule),
+    provideAnimations(),
+    provideHttpClient()
     // provide the HAMMER_GESTURE_CONFIG token
     // to override the default settings of the HammerModule
     // { provide: HAMMER_GESTURE_CONFIG, useClass: MyHammerConfig }


### PR DESCRIPTION
Adds the `provideHttpClient` method in the `providers` array for projects with standalone components.

Also sets the project type of legacy angular projects to `igx-ts-legacy` in the cli config.