### PR TITLE
fix(Imports): Fixed class import path in .test.ts

### DIFF
--- a/packages/cli/templates/react/igr-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/bullet-graph/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/category-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/category-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/doughnut-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/doughnut-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/financial-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/financial-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/grid/basic/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/grid/basic/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/linear-gauge/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/pie-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/pie-chart/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);

--- a/packages/cli/templates/react/igr-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.test.tsx
+++ b/packages/cli/templates/react/igr-ts/radial-gauge/default/files/src/app/__path__/__filePrefix__.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { render } from '@testing-library/react';
-import $(ClassName) from './index';
+import $(ClassName) from './$(path)';
 
 test('renders $(ClassName) component', () => {
     const wrapper = render(<$(ClassName) />);


### PR DESCRIPTION
Closes #1220 .  

Fixed grid and all other available templates to use `from './$(path)'` instead of the `'from ./index'`.