### PR TITLE
chore(webc): Bump the version of @web/dev-server in the WebC templates

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
-    "@web/dev-server": "^0.4.5",
+    "@web/dev-server": "^0.4.6",
     "@web/rollup-plugin-html": "^2.3.0",
     "@web/rollup-plugin-import-meta-assets": "^1.0.7",
     "@web/test-runner": "^0.18.0",

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/files/package.json
@@ -41,7 +41,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
-    "@web/dev-server": "^0.4.5",
+    "@web/dev-server": "^0.4.6",
     "@web/rollup-plugin-html": "^2.3.0",
     "@web/rollup-plugin-import-meta-assets": "^1.0.7",
     "@web/test-runner": "^0.18.0",


### PR DESCRIPTION
Closes #1256
The error is still shown but for a very brief moment this time:
![image](https://github.com/IgniteUI/igniteui-cli/assets/9549439/d89545e5-520c-4ff2-8713-677628e45705)


