### PR TITLE
Added mock implementations of HTMLElement.prototype functions in test setup

### DIFF
--- a/packages/cli/templates/react/igr-ts/projects/_base/files/src/setupTests.ts
+++ b/packages/cli/templates/react/igr-ts/projects/_base/files/src/setupTests.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom'
 import 'vitest-canvas-mock'
 import ResizeObserver from 'resize-observer-polyfill'
+import {vi} from 'vitest'
 
 global.ResizeObserver = ResizeObserver;
+
+HTMLElement.prototype.scrollIntoView = vi.fn();
+HTMLElement.prototype.hidePopover = vi.fn();
+HTMLElement.prototype.showPopover = vi.fn();
+HTMLElement.prototype.togglePopover = vi.fn();


### PR DESCRIPTION
Added mock implementations of HTMLElement.prototype functions that are still not implemented in react and cause errors upon app tests

Closes # .  

Additional information related to this pull request:

