### PR TITLE
Adding schema to template dependency

### DIFF
--- a/packages/core/types/TemplateDependency.ts
+++ b/packages/core/types/TemplateDependency.ts
@@ -9,6 +9,9 @@ export interface TemplateDependency {
 	/** Add an identifier into `ngModule` provides metadata */
 	provide?: string | string[];
 
+	/** Add an identifier into `ngModule` schema metadata */
+	schema?: string | string[];
+
 	/** The package/path(TBD) to import the dependency from */
 	from?: string;
 

--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -25,6 +25,7 @@ export class TypeScriptFileUpdate {
 		declarations: string[],
 		imports: Array<{ name: string, root: boolean, standalone?: boolean }>,
 		providers: string[],
+		schemas: string[],
 		exports: string[]
 	};
 
@@ -141,13 +142,14 @@ export class TypeScriptFileUpdate {
 			declare: this.asArray(dep.declare, variables),
 			import: this.asArray(dep.import, variables),
 			provide: this.asArray(dep.provide, variables),
+			schema: this.asArray(dep.schema, variables),
 			// tslint:disable-next-line:object-literal-sort-keys
 			export: this.asArray(dep.export, variables)
 		};
 
 		if (dep.from) {
 			// request import
-			const identifiers = [...copy.import, ...copy.declare, ...copy.provide];
+			const identifiers = [...copy.import, ...copy.declare, ...copy.provide, ...copy.schema];
 			this.requestImport(identifiers, Util.applyConfigTransformation(dep.from, variables));
 		}
 		const imports = copy.import
@@ -162,6 +164,10 @@ export class TypeScriptFileUpdate {
 		const providers = copy.provide
 			.filter(x => !this.ngMetaEdits.providers.find(p => p === x));
 		this.ngMetaEdits.providers.push(...providers);
+
+		const schemas = copy.schema
+			.filter(x => !this.ngMetaEdits.schemas.find(s => s === x));
+		this.ngMetaEdits.schemas.push(...schemas);
 
 		const exportsArr = copy.export
 			.filter(x => !this.ngMetaEdits.exports.find(p => p === x));
@@ -249,6 +255,7 @@ export class TypeScriptFileUpdate {
 			declarations: [],
 			imports: [],
 			providers: [],
+			schemas: [],
 			exports: []
 		};
 		this.createdStringLiterals = [];
@@ -557,6 +564,7 @@ export class TypeScriptFileUpdate {
 								break;
 							case "declarations":
 							case "providers":
+							case "schemas":
 							case "exports":
 								arrayExpr = ts.factory.createArrayLiteralExpression(
 									this.ngMetaEdits[prop].map(x => ts.factory.createIdentifier(x))

--- a/packages/core/typescript/TypeScriptFileUpdate.ts
+++ b/packages/core/typescript/TypeScriptFileUpdate.ts
@@ -186,7 +186,7 @@ export class TypeScriptFileUpdate {
 		};
 		if (dep.from) {
 			// request import
-			const identifiers = [...copy.import, ...copy.provide];
+			const identifiers = [...copy.import, ...copy.provide, ...copy.schema];
 			this.requestImport(identifiers, Util.applyConfigTransformation(dep.from, variables));
 		}
 


### PR DESCRIPTION
This PR allows the TSFU to add a schemas member to the `@NgModule` or `@Component` decorators in Angular.

Related:
https://github.com/IgniteUI/igniteui-cli/pull/1270
https://github.com/IgniteUI/igniteui-cli/pull/1278
https://github.com/IgniteUI/igniteui-cli/pull/1279