### PR TITLE
Adding 'ng lint' command in Angular Standalone templates 13.4

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve -o",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "lint": "ng lint"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

