### PR TITLE
Provide default package name in config for igx-ts projects

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/index.ts
+++ b/packages/igx-templates/igx-ts/projects/_base/index.ts
@@ -65,6 +65,7 @@ $app-palette: palette($primary, $secondary, $surface);
 			dot: ".",
 			path: name,
 			projectTemplate: this.id,
+			igxPackage: "igniteui-angular",
 			yamlDefaultBranch: "<%=yaml-default-branch%>", // the placeholder will be evaluated by CodeGen
 			ApplicationTitle: "<%=ApplicationTitle%>" // the placeholder will be evaluated by CodeGen
 		};

--- a/packages/igx-templates/igx-ts/projects/_base/index.ts
+++ b/packages/igx-templates/igx-ts/projects/_base/index.ts
@@ -1,4 +1,4 @@
-import { ControlExtraConfiguration, ProjectTemplate, Util, updateWorkspace } from "@igniteui/cli-core";
+import { ControlExtraConfiguration, NPM_ANGULAR, ProjectTemplate, Util, updateWorkspace } from "@igniteui/cli-core";
 import * as path from "path";
 
 export class BaseIgxProject implements ProjectTemplate {
@@ -65,7 +65,7 @@ $app-palette: palette($primary, $secondary, $surface);
 			dot: ".",
 			path: name,
 			projectTemplate: this.id,
-			igxPackage: "igniteui-angular",
+			igxPackage: NPM_ANGULAR,
 			yamlDefaultBranch: "<%=yaml-default-branch%>", // the placeholder will be evaluated by CodeGen
 			ApplicationTitle: "<%=ApplicationTitle%>" // the placeholder will be evaluated by CodeGen
 		};


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-cli/issues/1319

### Additional information related to this pull request:

This PR adds a missing `igxPackage` property in the config of the `base` template for the `igx-ts` project type i.e. projects that are based on Angular with standalone components.

Testing this should be done by running the wizard and ensuring that `igniteui-angular` exists in the `app.config.ts` when no license is applied and `@infragistics/igniteui-angular` exists when licensing is applied.
