### PR TITLE
fix(ng): use "skipLibCheck": true for legacy igx projects

### DIFF
--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/tsconfig.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "strict": true,
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
The `skipLibCheck` property is also defined in the standalone templates.

The problem was caught in the CodeGen angular module generated project, where there was a problem with the `igniteui-webcomponents` library (which is used by `igniteui-angular`, because the of the wc rating). `igniteui-webcomponents` is using `typescript@5.6`. while `igniteui-angular` is using `typescript@5.5` and the following error is shown:

```console
Error: node_modules/igniteui-webcomponents/components/icon/registry/default-map.d.ts:10:16 - error TS2552: Cannot find name 'MapIterator'. Did you mean 'Iterator'?        

10     entries(): MapIterator<[T, U]>;
                  ~~~~~~~~~~~
```
This is a Typescript API change from 5.5 to 5.6 and because the problem is not related to the generated angular project and it is running successfully, then `skipLibCheck: true` is a proper solution.

