### PR TITLE
resolve code scanning vulnerability alerts

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/grid/grid-editing/files/src/app/__path__/DataGridSharedData.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/grid/grid-editing/files/src/app/__path__/DataGridSharedData.ts
@@ -9,7 +9,7 @@ export class DataGridSharedData {
     let maleCount: number = 0;
     let femaleCount: number = 0;
     for (let i = 0; i < count; i += 1) {
-      const age: number = Math.round(this.getRandomNumber(20, 40));
+      const age: number = Math.round(this.getSecureRandomNumber(20, 40));
       const gender: string = this.getRandomGender();
       const firstName: string = this.getRandomNameFirst(gender);
       const lastName: string = this.getRandomNameLast();
@@ -52,8 +52,8 @@ export class DataGridSharedData {
       person.Phone = this.getRandomPhone();
       person.Photo = photoPath;
       person.Street = street;
-      person.Salary = this.getRandomNumber(40, 200) * 1000;
-      person.Sales = this.getRandomNumber(200, 980) * 1000;
+      person.Salary = this.getSecureRandomNumber(40, 200) * 1000;
+      person.Sales = this.getSecureRandomNumber(200, 980) * 1000;
       person.Website = website;
       person.Productivity = this.getProductivity();
 
@@ -202,6 +202,13 @@ export class DataGridSharedData {
 
   private static roadNames: string[] = ['Main', 'Garden', 'Broad', 'Oak', 'Cedar', 'Park', 'Pine', 'Elm', 'Market', 'Hill'];
 
+  private static getSecureRandomNumber(min: number, max: number): number {
+    const randomBuffer  = new Uint32Array(1);
+    window.crypto.getRandomValues(randomBuffer);
+    const randomNumber = randomBuffer [0] / (0xFFFFFFFF + 1);
+    return Math.round(min + randomNumber * (max - min));
+}
+
   private static getRandomNumber(min: number, max: number): number {
     return Math.round(min + Math.random() * (max - min));
   }
@@ -217,8 +224,8 @@ export class DataGridSharedData {
 
   private static getRandomPhone(): string {
     const phoneCode = this.getRandomNumber(100, 900);
-    const phoneNum1 = this.getRandomNumber(100, 900);
-    const phoneNum2 = this.getRandomNumber(1000, 9000);
+    const phoneNum1 = this.getSecureRandomNumber(100, 900);
+    const phoneNum2 = this.getSecureRandomNumber(1000, 9000);
     const phone = `${phoneCode}-${phoneNum1}-${phoneNum2}`;
     return phone;
   }

--- a/packages/cli/templates/webcomponents/igc-ts/grid/grid-editing/files/src/app/__path__/DataGridSharedData.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/grid/grid-editing/files/src/app/__path__/DataGridSharedData.ts
@@ -9,7 +9,7 @@ export class DataGridSharedData {
     let maleCount: number = 0;
     let femaleCount: number = 0;
     for (let i = 0; i < count; i += 1) {
-      const age: number = Math.round(this.getSecureRandomNumber(20, 40));
+      const age: number = Math.round(this.getRandomNumber(20, 40));
       const gender: string = this.getRandomGender();
       const firstName: string = this.getRandomNameFirst(gender);
       const lastName: string = this.getRandomNameLast();
@@ -52,8 +52,8 @@ export class DataGridSharedData {
       person.Phone = this.getRandomPhone();
       person.Photo = photoPath;
       person.Street = street;
-      person.Salary = this.getSecureRandomNumber(40, 200) * 1000;
-      person.Sales = this.getSecureRandomNumber(200, 980) * 1000;
+      person.Salary = this.getRandomNumber(40, 200) * 1000;
+      person.Sales = this.getRandomNumber(200, 980) * 1000;
       person.Website = website;
       person.Productivity = this.getProductivity();
 
@@ -202,13 +202,6 @@ export class DataGridSharedData {
 
   private static roadNames: string[] = ['Main', 'Garden', 'Broad', 'Oak', 'Cedar', 'Park', 'Pine', 'Elm', 'Market', 'Hill'];
 
-  private static getSecureRandomNumber(min: number, max: number): number {
-    const randomBuffer  = new Uint32Array(1);
-    window.crypto.getRandomValues(randomBuffer);
-    const randomNumber = randomBuffer [0] / (0xFFFFFFFF + 1);
-    return Math.round(min + randomNumber * (max - min));
-}
-
   private static getRandomNumber(min: number, max: number): number {
     return Math.round(min + Math.random() * (max - min));
   }
@@ -224,8 +217,8 @@ export class DataGridSharedData {
 
   private static getRandomPhone(): string {
     const phoneCode = this.getRandomNumber(100, 900);
-    const phoneNum1 = this.getSecureRandomNumber(100, 900);
-    const phoneNum2 = this.getSecureRandomNumber(1000, 9000);
+    const phoneNum1 = this.getRandomNumber(100, 900);
+    const phoneNum2 = this.getRandomNumber(1000, 9000);
     const phone = `${phoneCode}-${phoneNum1}-${phoneNum2}`;
     return phone;
   }

--- a/packages/core/packages/PackageManager.ts
+++ b/packages/core/packages/PackageManager.ts
@@ -1,4 +1,4 @@
-import { exec, spawnSync } from "child_process";
+import { exec } from "child_process";
 import * as path from "path";
 import { TemplateManager } from "../../cli/lib/TemplateManager";
 import { Config, FS_TOKEN, IFileSystem, ProjectTemplate } from "../types";
@@ -134,7 +134,7 @@ export class PackageManager {
 		}
 		try {
 			// tslint:disable-next-line:object-literal-sort-keys
-			spawnSync(managerCommand, args, { stdio: "pipe", encoding: "utf8" });
+			Util.spawnSync(managerCommand, args, { stdio: "pipe", encoding: "utf8" });
 		} catch (error) {
 			Util.log(`Error uninstalling package ${packageName} with ${managerCommand}`);
 			if (verbose) {
@@ -225,7 +225,7 @@ export class PackageManager {
 		const fullPackageRegistry = config.igPackageRegistry;
 		try {
 			// tslint:disable-next-line:object-literal-sort-keys
-			spawnSync('npm', ['whoami', `--registry=${fullPackageRegistry}`], { stdio: 'pipe', encoding: 'utf8' });
+			Util.spawnSync('npm', ['whoami', `--registry=${fullPackageRegistry}`], { stdio: 'pipe', encoding: 'utf8' });
 		} catch (error) {
 			// try registering the user:
 			Util.log(
@@ -247,14 +247,14 @@ export class PackageManager {
 				process.stdin.setRawMode(true);
 			}
 			const cmd = /^win/.test(process.platform) ? "npm.cmd" : "npm"; //https://github.com/nodejs/node/issues/3675
-			const login = spawnSync(cmd,
+			const login = Util.spawnSync(cmd,
 				["adduser", `--registry=${fullPackageRegistry}`, `--scope=@infragistics`, `--always-auth`],
 				{ stdio: "inherit" }
 			);
 			if (login?.status === 0) {
 				//make sure scope is configured:
 				try {
-					spawnSync('npm', ['config', 'set', `@infragistics:registry`, fullPackageRegistry]);
+					Util.spawnSync('npm', ['config', 'set', `@infragistics:registry`, fullPackageRegistry]);
 					return true;
 				} catch (error) {
 					return false;

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { execSync, ExecSyncOptions, spawnSync } from "child_process";
+import { execSync, ExecSyncOptions, spawnSync, SpawnSyncOptions } from "child_process";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
@@ -352,6 +352,32 @@ export class Util {
 	}
 
 	/**
+     * Execute synchronous command with options using spawnSync
+     * @param command Command to be executed
+     * @param args Command arguments
+     * @param options Command options
+     * @throws {Error} On non-zero exit code. Error has 'status', 'signal', 'output', 'stdout', 'stderr'
+     */
+	public static spawnSync(command: string, args: string[], options?: SpawnSyncOptions) {
+		try {
+			return spawnSync(command, args, options);
+		} catch (error) {
+			// Handle potential process interruption
+			// Check if the error output ends with "^C"
+			if (error.stderr && error.stderr.toString().endsWith() === "^C") {
+				return process.exit();
+			}
+
+			// Handle specific exit codes for different signals
+			if (error.status === 3221225786 || error.status > 128) {
+				return process.exit();
+			}
+
+			throw error;
+		}
+	}
+
+	/**
 	 * Initialize git for a project, located in the provided directory and commit it.
 	 * @param parentRoot Parent directory root of the project.
 	 * @param projectName Project name.
@@ -362,10 +388,7 @@ export class Util {
 			Util.execSync("git init", options);
 			Util.execSync("git add .", options);
 			const commitMessage = `"Initial commit for project: ${projectName}"`;
-			const commitResult = spawnSync('git', ['commit', '-m', commitMessage], options);
-			if (commitResult.error) {
-				throw commitResult.error;
-			}
+			Util.spawnSync('git', ['commit', '-m', commitMessage], options);
 			Util.log(Util.greenCheck() + " Git Initialized and Project '" + projectName + "' Committed");
 		} catch (error) {
 			Util.error("Git initialization failed. Install Git in order to automatically commit the project.", "yellow");

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { execSync, ExecSyncOptions, execFileSync } from "child_process";
+import { execSync, ExecSyncOptions, spawnSync } from "child_process";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
@@ -361,7 +361,11 @@ export class Util {
 			const options: any = { cwd: path.join(parentRoot, projectName), stdio: [process.stdin, "ignore", "ignore"] };
 			Util.execSync("git init", options);
 			Util.execSync("git add .", options);
-			execFileSync("git", ["commit", "-m", `Initial commit for project: ${projectName}`], options);
+			const commitMessage = `"Initial commit for project: ${projectName}"`;
+			const commitResult = spawnSync('git', ['commit', '-m', commitMessage], options);
+			if (commitResult.error) {
+				throw commitResult.error;
+			}
 			Util.log(Util.greenCheck() + " Git Initialized and Project '" + projectName + "' Committed");
 		} catch (error) {
 			Util.error("Git initialization failed. Install Git in order to automatically commit the project.", "yellow");

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -282,6 +282,11 @@ export class Util {
 		}
 
 		for (const key of Object.keys(source)) {
+			// Skip keys that can affect the prototype of objects to avoid prototype pollution vulnerabilities
+			if (key === "__proto__" || key === "constructor") {
+				continue;
+			}
+
 			const sourceKeyIsArray = Array.isArray(source[key]);
 			const targetHasThisKey = target.hasOwnProperty(key);
 
@@ -356,7 +361,9 @@ export class Util {
 			const options: any = { cwd: path.join(parentRoot, projectName), stdio: [process.stdin, "ignore", "ignore"] };
 			Util.execSync("git init", options);
 			Util.execSync("git add .", options);
-			Util.execSync("git commit -m " + "\"Initial commit for project: " + projectName + "\"", options);
+			// Validate projectName to prevent command injection. Allow only letters, numbers, dashes, underscores, and spaces
+			const safeProjectName = projectName.replace(/[^a-zA-Z0-9-_ ]/g, '');
+			Util.execSync(`git commit -m "Initial commit for project: ${safeProjectName}"`, options);
 			Util.log(Util.greenCheck() + " Git Initialized and Project '" + projectName + "' Committed");
 		} catch (error) {
 			Util.error("Git initialization failed. Install Git in order to automatically commit the project.", "yellow");

--- a/packages/core/util/Util.ts
+++ b/packages/core/util/Util.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { execSync, ExecSyncOptions } from "child_process";
+import { execSync, ExecSyncOptions, execFileSync } from "child_process";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
@@ -361,9 +361,7 @@ export class Util {
 			const options: any = { cwd: path.join(parentRoot, projectName), stdio: [process.stdin, "ignore", "ignore"] };
 			Util.execSync("git init", options);
 			Util.execSync("git add .", options);
-			// Validate projectName to prevent command injection. Allow only letters, numbers, dashes, underscores, and spaces
-			const safeProjectName = projectName.replace(/[^a-zA-Z0-9-_ ]/g, '');
-			Util.execSync(`git commit -m "Initial commit for project: ${safeProjectName}"`, options);
+			execFileSync("git", ["commit", "-m", `Initial commit for project: ${projectName}`], options);
 			Util.log(Util.greenCheck() + " Git Initialized and Project '" + projectName + "' Committed");
 		} catch (error) {
 			Util.error("Git initialization failed. Install Git in order to automatically commit the project.", "yellow");

--- a/spec/acceptance/help-spec.ts
+++ b/spec/acceptance/help-spec.ts
@@ -1,5 +1,4 @@
-import { GoogleAnalytics } from "@igniteui/cli-core";
-import { spawnSync } from "child_process";
+import { GoogleAnalytics, Util } from "@igniteui/cli-core";
 import * as cli from "../../packages/cli/lib/cli";
 
 const execLocation = "packages/cli/bin/execute.js";
@@ -37,7 +36,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the new command", async () => {
-		const child = spawnSync("node", [execLocation, "new", "--help"], {
+		const child = Util.spawnSync("node", [execLocation, "new", "--help"], {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `Options:
@@ -60,7 +59,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the config sub-commands", async () => {
-		const child = spawnSync("node", [execLocation, "config", "--help"], {
+		const child = Util.spawnSync("node", [execLocation, "config", "--help"], {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `Commands:
@@ -80,7 +79,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the generate sub-commands", async () => {
-		const child = spawnSync("node", [execLocation, "generate", "--help"], {
+		const child = Util.spawnSync("node", [execLocation, "generate", "--help"], {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `Commands:
@@ -97,7 +96,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the generate template sub-commands", async () => {
-		const child = spawnSync("node", [execLocation, "g", "t", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "g", "t", "-h"], {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `
@@ -119,7 +118,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the list command", async () => {
-		const child = spawnSync("node", [execLocation, "list", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "list", "-h"], {
 			encoding: "utf-8"
 		});
 		const originalNewHelpText: string = `
@@ -137,7 +136,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the quickstart command", async () => {
-		const child = spawnSync("node", [execLocation, "quickstart", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "quickstart", "-h"], {
 			encoding: "utf-8"
 		});
 
@@ -156,7 +155,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the test command", async () => {
-		const child = spawnSync("node", [execLocation, "test", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "test", "-h"], {
 			encoding: "utf-8"
 		});
 
@@ -174,7 +173,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the doc command", async () => {
-		const child = spawnSync("node", [execLocation, "doc", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "doc", "-h"], {
 			encoding: "utf-8"
 		});
 
@@ -192,7 +191,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the build command", async () => {
-		const child = spawnSync("node", [execLocation, "build", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "build", "-h"], {
 			encoding: "utf-8"
 		});
 
@@ -210,7 +209,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the start command", async () => {
-		const child = spawnSync("node", [execLocation, "start", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "start", "-h"], {
 			encoding: "utf-8"
 		});
 
@@ -228,7 +227,7 @@ describe("Help command", () => {
 	});
 
 	it("should show help for the upgrade command", async () => {
-		const child = spawnSync("node", [execLocation, "upgrade-packages", "-h"], {
+		const child = Util.spawnSync("node", [execLocation, "upgrade-packages", "-h"], {
 			encoding: "utf-8"
 		});
 

--- a/spec/unit/new-spec.ts
+++ b/spec/unit/new-spec.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import { default as newCmd } from "../../packages/cli/lib/commands/new";
 import { PromptSession } from "../../packages/cli/lib/PromptSession";
 import { resetSpy } from "../helpers/utils";
-import child_process from "child_process";
 
 function createMockBaseTemplate(): BaseTemplate {
 	return {
@@ -285,7 +284,7 @@ describe("Unit - New command", () => {
 			getProjectLibrary: mockProjLib
 		});
 
-		spyOn(child_process, "spawnSync").and.returnValues({
+		spyOn(Util, "spawnSync").and.returnValues({
 			status: 0,
 			pid: 0,
 			output: [],
@@ -298,7 +297,7 @@ describe("Unit - New command", () => {
 
 		expect(Util.execSync).toHaveBeenCalledWith("git init", jasmine.any(Object));
 		expect(Util.execSync).toHaveBeenCalledWith("git add .", jasmine.any(Object));
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			"git",
 			['commit', '-m', `"Initial commit for project: ${projectName}"`],
 			{ cwd: path.join(process.cwd(), projectName), stdio: [process.stdin, "ignore", "ignore"] }

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -39,20 +39,22 @@ describe("Unit - Package Manager", () => {
 		};
 		// should ignore already installed
 		spyOn(App.container, "get").and.returnValue(mockFs);
-		spyOn(Util, "execSync").and.callFake((cmd: string, opts) => {
-			if (cmd.includes("whoami")) {
+
+		const fakeSpawnSync = (cmd: any, args: string[], opts: any) => {
+			if (args.includes("whoami")) {
 				throw new Error("");
 			}
-			return "";
-		});
-		spyOn(child_process, "spawnSync").and.returnValues({
-			status: 0,
-			pid: 0,
-			output: [],
-			stdout: "",
-			stderr: "",
-			signal: "SIGABRT"
-		});
+			return {
+                status: 0,
+                pid: 0,
+                output: [],
+            	stdout: "",
+				stderr: "",
+				signal: "SIGABRT"
+            };
+		};
+		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+
 		spyOn(Util, "log");
 		spyOn(PackageManager, "removePackage");
 		await PackageManager.ensureIgniteUISource(true, mockTemplateMgr, true);
@@ -82,7 +84,10 @@ describe("Unit - Package Manager", () => {
 				stdio: "inherit"
 			}
 		);
-		expect(Util.execSync).toHaveBeenCalledWith("npm config set @infragistics:registry trial");
+		expect(child_process.spawnSync).toHaveBeenCalledWith(
+			"npm",
+			['config', 'set', `@infragistics:registry`, mockProjectConfig.igPackageRegistry]
+		);
 		expect(PackageManager.removePackage).toHaveBeenCalled();
 		expect(PackageManager.addPackage).toHaveBeenCalledWith(`@infragistics/ignite-ui-full@"20.1"`, true);
 	});
@@ -115,18 +120,25 @@ describe("Unit - Package Manager", () => {
 		spyOn(ProjectConfig, "localConfig").and.returnValue(mockProjectConfig);
 		spyOn(ProjectConfig, "setConfig");
 		spyOn(TestPackageManager, "addPackage").and.returnValue(true);
-		spyOn(Util, "execSync").and.throwError("no user");
+
+		const fakeSpawnSync = (cmd: any, args: string[], opts: any) => {
+			if (args.includes("whoami")) {
+				throw new Error("no user");
+			}
+			return {
+                status: 1,
+                pid: 0,
+                output: [],
+            	stdout: "",
+				stderr: "",
+				signal: "SIGABRT"
+            };
+		};
+		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+
 		spyOn(Util, "log");
 		spyOn(TestPackageManager, "removePackage");
 		spyOn(TestPackageManager, "getPackageJSON").and.callFake(() => mockRequire);
-		spyOn(child_process, "spawnSync").and.returnValues({
-			status: 1,
-			pid: 0,
-			output: [],
-			stdout: "",
-			stderr: "",
-			signal: "SIGABRT"
-		});
 		await TestPackageManager.ensureIgniteUISource(true, mockTemplateMgr, true);
 		expect(ProjectConfig.localConfig).toHaveBeenCalled();
 		expect(Util.log).toHaveBeenCalledTimes(12);
@@ -169,8 +181,14 @@ describe("Unit - Package Manager", () => {
 				stdio: "inherit"
 			}
 		);
-		expect(Util.execSync).toHaveBeenCalledTimes(2);
-		expect(Util.execSync).toHaveBeenCalledWith(`npm whoami --registry=trial`, { stdio: "pipe", encoding: "utf8" });
+		expect(child_process.spawnSync).toHaveBeenCalledWith(
+			"npm",
+			['whoami', `--registry=${mockProjectConfig.igPackageRegistry}`],
+			{
+				stdio: "pipe",
+				encoding: "utf8"
+			}
+		);
 	});
 	it("ensureIgniteUISource - Should run through properly when install now is set to false", async () => {
 		spyOn(Util, "log");
@@ -320,27 +338,41 @@ describe("Unit - Package Manager", () => {
 	});
 	it("Should run removePackage properly with error code", async () => {
 		spyOn(Util, "log");
-		spyOn(Util, "execSync").and.callFake(() => {
-			const err = new Error("Error");
-			err["status"] = 1;
-			throw err;
-		});
+		const fakeSpawnSync = (cmd: any, args: string[], opts: any) => {
+			throw new Error("Error");
+		};
+		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
 		PackageManager.removePackage("example-package", true);
 		expect(Util.log).toHaveBeenCalledTimes(2);
 		expect(Util.log).toHaveBeenCalledWith(`Error uninstalling package example-package with npm`);
 		expect(Util.log).toHaveBeenCalledWith(`Error`);
-		expect(Util.execSync).toHaveBeenCalledWith(
-			`npm uninstall example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" }
+		expect(child_process.spawnSync).toHaveBeenCalledWith(
+			`npm`,
+			['uninstall', "example-package", '--quiet', '--save'],
+			{ stdio: "pipe", encoding: "utf8" }
 		);
 	});
 	it("Should run removePackage properly without error code", async () => {
 		spyOn(Util, "log");
-		spyOn(Util, "execSync").and.returnValue("");
+		const fakeSpawnSync = (cmd: any, args: string[], opts: any) => {
+			return {
+                status: 0,
+                pid: 0,
+                output: [],
+            	stdout: "",
+				stderr: "",
+				signal: "SIGABRT"
+            };
+		};
+		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
 		PackageManager.removePackage("example-package");
 		expect(Util.log).toHaveBeenCalledTimes(1);
 		expect(Util.log).toHaveBeenCalledWith(`Package example-package uninstalled successfully`);
-		expect(Util.execSync).toHaveBeenCalledWith(
-			`npm uninstall example-package --quiet --save`, { stdio: "pipe", encoding: "utf8" });
+		expect(child_process.spawnSync).toHaveBeenCalledWith(
+			`npm`,
+			['uninstall', "example-package", '--quiet', '--save'],
+			{ stdio: "pipe", encoding: "utf8" }
+		);
 	});
 	it("Should run addPackage properly with error code", async () => {
 		spyOn(Util, "log");

--- a/spec/unit/packageManager-spec.ts
+++ b/spec/unit/packageManager-spec.ts
@@ -53,7 +53,7 @@ describe("Unit - Package Manager", () => {
 				signal: "SIGABRT"
             };
 		};
-		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+		spyOn(Util, 'spawnSync').and.callFake(fakeSpawnSync as any);
 
 		spyOn(Util, "log");
 		spyOn(PackageManager, "removePackage");
@@ -77,14 +77,14 @@ describe("Unit - Package Manager", () => {
 			"yellow"
 		);
 		expect(path.join).toHaveBeenCalled();
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			/^win/.test(process.platform) ? "npm.cmd" : "npm",
 			["adduser", `--registry=trial`, `--scope=@infragistics`, `--always-auth`],
 			{
 				stdio: "inherit"
 			}
 		);
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			"npm",
 			['config', 'set', `@infragistics:registry`, mockProjectConfig.igPackageRegistry]
 		);
@@ -134,7 +134,7 @@ describe("Unit - Package Manager", () => {
 				signal: "SIGABRT"
             };
 		};
-		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+		spyOn(Util, 'spawnSync').and.callFake(fakeSpawnSync as any);
 
 		spyOn(Util, "log");
 		spyOn(TestPackageManager, "removePackage");
@@ -174,14 +174,14 @@ describe("Unit - Package Manager", () => {
 			`for instructions on how to install the full package.`,
 			"yellow"
 		); // x1
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			/^win/.test(process.platform) ? "npm.cmd" : "npm",
 			["adduser", `--registry=trial`, `--scope=@infragistics`, `--always-auth`],
 			{
 				stdio: "inherit"
 			}
 		);
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			"npm",
 			['whoami', `--registry=${mockProjectConfig.igPackageRegistry}`],
 			{
@@ -341,12 +341,12 @@ describe("Unit - Package Manager", () => {
 		const fakeSpawnSync = (cmd: any, args: string[], opts: any) => {
 			throw new Error("Error");
 		};
-		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+		spyOn(Util, 'spawnSync').and.callFake(fakeSpawnSync as any);
 		PackageManager.removePackage("example-package", true);
 		expect(Util.log).toHaveBeenCalledTimes(2);
 		expect(Util.log).toHaveBeenCalledWith(`Error uninstalling package example-package with npm`);
 		expect(Util.log).toHaveBeenCalledWith(`Error`);
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			`npm`,
 			['uninstall', "example-package", '--quiet', '--save'],
 			{ stdio: "pipe", encoding: "utf8" }
@@ -364,11 +364,11 @@ describe("Unit - Package Manager", () => {
 				signal: "SIGABRT"
             };
 		};
-		spyOn(child_process, 'spawnSync').and.callFake(fakeSpawnSync as any);
+		spyOn(Util, 'spawnSync').and.callFake(fakeSpawnSync as any);
 		PackageManager.removePackage("example-package");
 		expect(Util.log).toHaveBeenCalledTimes(1);
 		expect(Util.log).toHaveBeenCalledWith(`Package example-package uninstalled successfully`);
-		expect(child_process.spawnSync).toHaveBeenCalledWith(
+		expect(Util.spawnSync).toHaveBeenCalledWith(
 			`npm`,
 			['uninstall', "example-package", '--quiet', '--save'],
 			{ stdio: "pipe", encoding: "utf8" }


### PR DESCRIPTION
Resolve Vulnerability alerts in the igniteui-cli

Code scanning alerts fixes:
- Dismiss the insecure randomness alerts because this is only used for dummy data, and there is no need for security in this case.
- Replace execSync with spawnSync to avoid constructing the shell command by concatenating strings with untrusted input.
- Add check to ensure that the function does not allow merging of special properties like proto and constructor.

