### PR TITLE
resolve dependabot vulnerability alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"glob": "^11.0.0",
 		"jasmine": "^5.3.0",
 		"jasmine-spec-reporter": "^7.0.0",
-		"lerna": "^3.16.4",
+		"lerna": "^8.1.9",
 		"lerna-changelog": "^0.8.2",
 		"lite-server": "^2.6.1",
 		"nyc": "^17.0.0",
@@ -85,6 +85,10 @@
 		"tslint": "^5.11.0",
 		"typescript": "~5.5.4",
 		"typescript-json-schema": "^0.65.1"
+	},
+	"resolutions": {
+		"parse-url": "^8.1.0",
+		"braces": "^3.0.3"
 	},
 	"workspaces": [
 		"packages/*"

--- a/packages/cli/templates/jquery/js/projects/empty/files/package.json
+++ b/packages/cli/templates/jquery/js/projects/empty/files/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "browser-sync": "^2.26.3",
     "igniteui-cli": "^$(cliVersion)",
-    "karma": "^1.7.1",
+    "karma": "^6.4.4",
     "karma-chrome-launcher": "^2.2.0",
     "karma-qunit": "^1.2.1",
     "qunitjs": "^2.4.1"

--- a/packages/cli/templates/quickstart/react/package.json
+++ b/packages/cli/templates/quickstart/react/package.json
@@ -37,6 +37,6 @@
     "html-webpack-plugin": "2.26.0",
     "style-loader": "0.13.1",
     "webpack": "5.94.0",
-    "webpack-dev-server": "2.2.0"
+    "webpack-dev-server": "^5.1.0"
   }
 }


### PR DESCRIPTION
Resolve Vulnerability alerts in the igniteui-cli

Dependabot alerts fixes:
- templates: upgrade karma to 6.4.4 and webpck-dev-server to 5.1.0
- root: upgrade parse-url to 8.1.0, braces to 3.0.3

