### PR TITLE
Removing global replacement.

### DIFF
--- a/packages/cli/templates/react/igr-ts/projects/_base/files/vite.config.ts
+++ b/packages/cli/templates/react/igr-ts/projects/_base/files/vite.config.ts
@@ -4,7 +4,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  define: process.env.VITEST ? {} : { global: 'window' },
   plugins: [react()],
   test: {
     globals: true,


### PR DESCRIPTION
Removing 'define' from vite.config. 

This configuration tells Vite to replace all instances of `global` with `window` in the code before building the project. It's essentially a straightforward text replacement or string substitution mechanism. Any occurrence of the word `global` in the code will be replaced with `window`, regardless of the context. This means if the project have variables, function names, or anything else that contains `global` as a substring (like `globalView`, `isGlobalEnabled`), these will also be replaced.


