### PR TITLE
Fix pattern matching when upgrading packages

### DIFF
--- a/packages/core/types/FileSystem.ts
+++ b/packages/core/types/FileSystem.ts
@@ -8,8 +8,9 @@ export interface IFileSystem {
 	 * Returns a list of file paths under a directory based on a match pattern
 	 * @param dirPath Root dir to search in
 	 * @param pattern Pattern to match
+	 * @param ignorePatterns Optional pattern to ignore for each subdirectory
 	 */
-	glob(dirPath: string, pattern: string, ignorePattern?: string): string[];
+	glob(dirPath: string, pattern: string, ignorePatterns?: string[]): string[];
 }
 
 export const FS_TOKEN: string = "fs";

--- a/packages/core/update/Update.ts
+++ b/packages/core/update/Update.ts
@@ -61,7 +61,7 @@ export async function updateWorkspace(rootPath: string): Promise<boolean> {
 	const logicFiles = [];
 	const styleFiles = [];
 	const pkgJsonFiles = [];
-	pkgJsonFiles.push(...fs.glob(rootPath, `package.json`, "node_modules"));
+	pkgJsonFiles.push(...fs.glob(rootPath, `package.json`, ['node_modules', 'dist']));
 
 	let workspaceConfig = null;
 	switch (framework.toLowerCase()) {

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -23,11 +23,13 @@
     "@igniteui/angular-templates": "~19.0.1430",
     "@igniteui/cli-core": "~14.3.0",
     "@schematics/angular": "~19.0.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "minimatch": "^10.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "^5.1.4",
     "@types/node": "^22.5.5",
+	"@types/minimatch": "^5.1.2",
     "jasmine": "^5.3.0",
     "typescript": "~5.6.2"
   },

--- a/packages/ng-schematics/src/upgrade-packages/index.ts
+++ b/packages/ng-schematics/src/upgrade-packages/index.ts
@@ -18,9 +18,9 @@ export default function(options: UpgradeOptions): Rule {
 		});
 		const templateManager = new SchematicsTemplateManager();
 		const config = ProjectConfig.getConfig();
-		const library = templateManager.getProjectLibrary(config.project.framework, config.project.projectType);
+		const library = templateManager.getProjectLibrary('angular', config.project?.projectType || 'igx-ts');
 		let project: ProjectTemplate;
-		if (!config.project.projectTemplate || !library.hasProject(config.project.projectTemplate)) {
+		if (!config.project?.projectTemplate || !library.hasProject(config.project?.projectTemplate)) {
 			// in case project template is missing from the config we provide backward.
 			project = library.getProject(library.projectIds[0]);
 		} else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,7 +4915,7 @@ minimatch@9.0.3:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^10.0.0:
+minimatch@^10.0.0, minimatch@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
   integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
@@ -6701,7 +6701,16 @@ stream-throttle@^0.1.3:
     commander "^2.2.0"
     limiter "^1.0.5"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6761,7 +6770,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7408,7 +7424,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7421,6 +7437,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-cli/issues/1298

Additional information related to this pull request:

This PR modifies the `NgFileSystem`'s `glob` function to expect multiple ignore patterns. It then loops through the contents of the root directory and its subdirectories, ignoring all entries that match any of the provided patterns and collects only the entries that match the expected pattern. Angular's file visitor is used only if no ignore patterns are provided. Additionally, when upgrading packages, the `dist` folder is now also ignored.

Currently the `@igniteui/angular-schematics:upgrade-packages` schematic will fail for projects that have not defined an `ignite-ui-cli.json` config file. The reason is that, at runtime, the schematic will attempt to infer the project's framework from the local config file. This is a rather easy thing to fix but should be done in a separate PR. So, note for testing - a project should always have a config file when attempting to run schematics or cli commands.

