### PR TITLE
Disable standalone lint check and fix paths for angular modules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.2",
+  "version": "14.3.3-beta.0",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -78,8 +78,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.0.1432",
-    "@igniteui/cli-core": "~14.3.2",
+    "@igniteui/angular-templates": "~19.0.1433-beta.0",
+    "@igniteui/cli-core": "~14.3.3-beta.0",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.2",
+  "version": "14.3.3-beta.0",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/__dot__eslintrc.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/__dot__eslintrc.json
@@ -34,7 +34,8 @@
         "prefix": "app",
         "style": "kebab-case"
       }
-      ]
+      ],
+      "@angular-eslint/prefer-standalone": "off"
     }
     },
     {

--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/__dot__github/workflows/github-pages.yml
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/__dot__github/workflows/github-pages.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Build project with dynamic base-href
       run: npm run build -- --base-href "/${{ github.event.repository.name }}/"
     - name: Update Resource Paths
-      run: find ./dist/${{ env.PROJECT_NAME }} -type f -name '*main*.js' -exec sed -i -e "s|/assets|/${{ github.event.repository.name }}/assets|g" -e "s|url('/assets|url('/${{ github.event.repository.name }}/assets|g" {} +
+      run: find ./dist/${{ env.PROJECT_NAME }}/browser -type f -name '*main*.js' -exec sed -i -e "s|/assets|/${{ github.event.repository.name }}/assets|g" -e "s|url('/assets|url('/${{ github.event.repository.name }}/assets|g" {} +
     - name: SPA routing handling
-      run: cp ./dist/${{ env.PROJECT_NAME }}/index.html ./dist/${{ env.PROJECT_NAME }}/404.html
+      run: cp ./dist/${{ env.PROJECT_NAME }}/browser/index.html ./dist/${{ env.PROJECT_NAME }}/browser/404.html
     - name: Upload build artifact to GitHub Pages
       uses: actions/upload-pages-artifact@v1
       with:
-        path: ./dist/${{ env.PROJECT_NAME }}
+        path: ./dist/${{ env.PROJECT_NAME }}/browser
     - name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v1

--- a/packages/igx-templates/igx-ts-legacy/projects/_base_with_home/files/__dot__github/workflows/github-pages.yml
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base_with_home/files/__dot__github/workflows/github-pages.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Build project with dynamic base-href
       run: npm run build -- --base-href "/${{ github.event.repository.name }}/"
     - name: Update Resource Paths
-      run: find ./dist/${{ env.PROJECT_NAME }} -type f -name '*main*.js' -exec sed -i -e "s|/assets|/${{ github.event.repository.name }}/assets|g" -e "s|url('/assets|url('/${{ github.event.repository.name }}/assets|g" {} +
+      run: find ./dist/${{ env.PROJECT_NAME }}/browser -type f -name '*main*.js' -exec sed -i -e "s|/assets|/${{ github.event.repository.name }}/assets|g" -e "s|url('/assets|url('/${{ github.event.repository.name }}/assets|g" {} +
     - name: SPA routing handling
-      run: cp ./dist/${{ env.PROJECT_NAME }}/index.html ./dist/${{ env.PROJECT_NAME }}/404.html
+      run: cp ./dist/${{ env.PROJECT_NAME }}/browser/index.html ./dist/${{ env.PROJECT_NAME }}/browser/404.html
     - name: Upload build artifact to GitHub Pages
       uses: actions/upload-pages-artifact@v1
       with:
-        path: ./dist/${{ env.PROJECT_NAME }}
+        path: ./dist/${{ env.PROJECT_NAME }}/browser
     - name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v1

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.0.1432",
+  "version": "19.0.1433-beta.0",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.2",
+    "@igniteui/cli-core": "~14.3.3-beta.0",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.0.1432",
+  "version": "19.0.1433-beta.0",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.0.1432",
-    "@igniteui/cli-core": "~14.3.2",
+    "@igniteui/angular-templates": "~19.0.1433-beta.0",
+    "@igniteui/cli-core": "~14.3.3-beta.0",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
Disable standalone lint check for angular modules and fix paths in github pages yaml files for angular modules.

