### PR TITLE
feat: increase maximum file size to cache in webComponents's vite configuration to 10 MB

### DIFF
--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
             handler: 'CacheFirst',
           },
         ],
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024
+        maximumFileSizeToCacheInBytes: 10 * 1024 * 1024 // 10 MB
       },
     }),
   ],


### PR DESCRIPTION
Increase maximum file size to cache in webComponents's vite configuration to 10 MB

Additional information related to this pull request:

