### PR TITLE
fix: add overrides for reveal sdk wrappers

### DIFF
--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/package.json
@@ -31,6 +31,10 @@
         "@angular/core": "^19.0.0",
         "@angular/common": "^19.0.0",
         "@angular/compiler": "^19.0.0"
+    },
+    "reveal-sdk-wrappers-angular": {
+      "@angular/core": "^19.0.0",
+      "@angular/common": "^19.0.0"
     }
   },
   "devDependencies": {

--- a/packages/igx-templates/igx-ts/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/package.json
@@ -31,6 +31,10 @@
         "@angular/core": "^19.0.0",
         "@angular/common": "^19.0.0",
         "@angular/compiler": "^19.0.0"
+    },
+    "reveal-sdk-wrappers-angular": {
+      "@angular/core": "^19.0.0",
+      "@angular/common": "^19.0.0"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Add overrides for  "@angular/core": "^19.0.0" and "@angular/common": "^19.0.0" for reveal-sdk-wrappers-angular
