### PR TITLE
fix(workflows): Do not throw error if github workflows directory does…

### DIFF
--- a/packages/core/update/Update.ts
+++ b/packages/core/update/Update.ts
@@ -208,10 +208,12 @@ function updateWorkflows(
 
 	for (const fileName of workflowFiles) {
 		const workflowPath = `.github/workflows/${fileName}`;
-		let workflow = fs.readFile(workflowPath);
-		if (workflow) {
-			workflow = workflow.replace(oldNpmInstall, newNpmInstall);
-			fs.writeFile(workflowPath, workflow);
+		if (fs.fileExists(workflowPath)) {
+			let workflow = fs.readFile(workflowPath);
+			if (workflow) {
+				workflow = workflow.replace(oldNpmInstall, newNpmInstall);
+				fs.writeFile(workflowPath, workflow);
+			}
 		}
 	}
 }


### PR DESCRIPTION
… not exist when updating


Additional information related to this pull request:
When using ig uprage-packages within a project without `.github/workflows` directory it throws an error that it does not exist