### PR TITLE
fix: add missing static css files for WC

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.18-beta.0",
+  "version": "14.3.18-beta.1",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.1.14318-beta.0",
-    "@igniteui/cli-core": "~14.3.18-beta.0",
+    "@igniteui/angular-templates": "~19.1.14318-beta.1",
+    "@igniteui/cli-core": "~14.3.18-beta.1",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.8-beta.3",
+  "version": "14.3.18-beta.4",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.1.1438-beta.3",
-    "@igniteui/cli-core": "~14.3.8-beta.3",
+    "@igniteui/angular-templates": "~19.1.14318-beta.4",
+    "@igniteui/cli-core": "~14.3.18-beta.4",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.16",
+  "version": "14.3.18-beta.0",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.1.14316",
-    "@igniteui/cli-core": "~14.3.16",
+    "@igniteui/angular-templates": "~19.1.14318-beta.0",
+    "@igniteui/cli-core": "~14.3.18-beta.0",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.18-beta.1",
+  "version": "14.3.18-beta.2",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.1.14318-beta.1",
-    "@igniteui/cli-core": "~14.3.18-beta.1",
+    "@igniteui/angular-templates": "~19.1.14318-beta.2",
+    "@igniteui/cli-core": "~14.3.18-beta.2",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.3.18-beta.2",
+  "version": "14.3.8-beta.3",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~19.1.14318-beta.2",
-    "@igniteui/cli-core": "~14.3.18-beta.2",
+    "@igniteui/angular-templates": "~19.1.1438-beta.3",
+    "@igniteui/cli-core": "~14.3.8-beta.3",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/__dot__github/workflows/github-pages.yml
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/__dot__github/workflows/github-pages.yml
@@ -41,8 +41,6 @@ jobs:
         sed -i 's|<base href="[^"]*">|<base href="/${{ github.event.repository.name }}/">|' ./dist/index.html
     - name: Update Resource Paths
       run: find ./dist -maxdepth 1 -type f ! -name 'sw*.js' ! -name 'workbox*.js' -name '*.js' -exec sed -i -e "s|/src/assets|/${{ github.event.repository.name }}/src/assets|g" -e "s|url('/src/assets|url('/${{ github.event.repository.name }}/src/assets|g" {} +
-    - name: Copy ig-theme.css to dist
-      run: cp ./ig-theme.css ./dist/
     - name: Update href Paths for ig-theme.css
       run: |
         find ./dist -type f -exec sed -i "s|href='../../ig-theme.css'|href='../../${{ github.event.repository.name }}/ig-theme.css'|g" {} +;

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/__dot__github/workflows/github-pages.yml
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/__dot__github/workflows/github-pages.yml
@@ -41,10 +41,6 @@ jobs:
         sed -i 's|<base href="[^"]*">|<base href="/${{ github.event.repository.name }}/">|' ./dist/index.html
     - name: Update Resource Paths
       run: find ./dist -maxdepth 1 -type f ! -name 'sw*.js' ! -name 'workbox*.js' -name '*.js' -exec sed -i -e "s|/src/assets|/${{ github.event.repository.name }}/src/assets|g" -e "s|url('/src/assets|url('/${{ github.event.repository.name }}/src/assets|g" {} +
-    - name: Update href Paths for ig-theme.css
-      run: |
-        find ./dist -type f -exec sed -i "s|href='../../ig-theme.css'|href='../../${{ github.event.repository.name }}/ig-theme.css'|g" {} +;
-        find ./dist -type f -exec sed -i "s|href=\"../../ig-theme.css\"|href=\"../../${{ github.event.repository.name }}/ig-theme.css\"|g" {} +;
     - name: SPA routing handling
       run: cp ./dist/index.html ./dist/404.html
     - name: Upload build artifact to GitHub Pages

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/package.json
@@ -13,7 +13,7 @@
     "./$(dashName).js": "./dist/src/$(dashName).js"
   },
   "scripts": {
-    "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
+    "start": "concurrently -k -r \"tsc --watch\" \"vite\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/vite/bin/vite.js build",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-pattern .gitignore",

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/src/app/models/css.d.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/src/app/models/css.d.ts
@@ -1,0 +1,5 @@
+declare module '*.css?inline' {
+  import { CSSResult } from 'lit';
+  const content: CSSResult;
+  export default content;
+}

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import fs from 'fs';
+
+const gridMaterialCssPath = [
+  'node_modules/igniteui-webcomponents-grids/grids/themes/light/material.css',
+  'node_modules/@infragistics/igniteui-webcomponents-grids/grids/themes/light/material.css'
+].find(fs.existsSync) || null;
 
 export default defineConfig({
   build: {
@@ -21,10 +27,21 @@ export default defineConfig({
     chunkSizeWarningLimit: 10 * 1024 * 1024 // 10 MB
   },
   plugins: [
+    {
+      name: 'replace-grid-material-css-path',
+      apply: 'build',
+      transform(code, id) {
+        if (gridMaterialCssPath && id.endsWith('.js')) {
+          return code.replace(gridMaterialCssPath, '../../material.css');
+        }
+      }
+    },
     /** Copy static assets */
     viteStaticCopy({
       targets: [
         { src: 'src/assets', dest: 'src' },
+        { src: 'ig-theme.css', dest: '' },
+        ...(gridMaterialCssPath ? [{ src: gridMaterialCssPath, dest: '' }] : [])
       ],
       silent: true,
     }),

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
   },
   plugins: [
     {
-      name: 'replace-grid-material-css-path',
+      name: 'replace-grid-css-paths',
       apply: 'build',
       transform(code, id) {
         if (id.endsWith('.js')) {

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/vite.config.ts
@@ -1,18 +1,6 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import fs from 'fs';
-import path from 'path';
-
-const themeColors = ["light", "dark"];
-const themeTypes = ["material", "bootstrap", "indigo", "fluent"];
-const basePaths = [
-  "node_modules/igniteui-webcomponents-grids/grids/themes",
-  "node_modules/@infragistics/igniteui-webcomponents-grids/grids/themes"
-];
-const themeFiles = themeColors.flatMap(color =>
-  themeTypes.flatMap(theme => basePaths.map(basePath => `${basePath}/${color}/${theme}.css`))
-).filter(fs.existsSync);
 
 export default defineConfig({
   build: {
@@ -33,22 +21,10 @@ export default defineConfig({
     chunkSizeWarningLimit: 10 * 1024 * 1024 // 10 MB
   },
   plugins: [
-    {
-      name: 'replace-grid-css-paths',
-      apply: 'build',
-      transform(code, id) {
-        if (id.endsWith('.js')) {
-          themeFiles.forEach(t => { code = code.replaceAll(t, `../../${path.basename(t)}`); });
-          return code;
-        }
-      }
-    },
     /** Copy static assets */
     viteStaticCopy({
       targets: [
-        { src: 'src/assets', dest: 'src' },
-        { src: 'ig-theme.css', dest: '' },
-        ...themeFiles.map(themePath => ({ src: themePath, dest: '' }))
+        { src: 'src/assets', dest: 'src' }
       ],
       silent: true,
     }),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.16",
+  "version": "14.3.18-beta.0",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.18-beta.2",
+  "version": "14.3.8-beta.3",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.8-beta.3",
+  "version": "14.3.18-beta.4",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.18-beta.0",
+  "version": "14.3.18-beta.1",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.3.18-beta.1",
+  "version": "14.3.18-beta.2",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.1.1438-beta.3",
+  "version": "19.1.14318-beta.4",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.8-beta.3",
+    "@igniteui/cli-core": "~14.3.18-beta.4",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.1.14318-beta.0",
+  "version": "19.1.14318-beta.1",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.18-beta.0",
+    "@igniteui/cli-core": "~14.3.18-beta.1",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.1.14318-beta.1",
+  "version": "19.1.14318-beta.2",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.18-beta.1",
+    "@igniteui/cli-core": "~14.3.18-beta.2",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.1.14318-beta.2",
+  "version": "19.1.1438-beta.3",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.18-beta.2",
+    "@igniteui/cli-core": "~14.3.8-beta.3",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "19.1.14316",
+  "version": "19.1.14318-beta.0",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.3.16",
+    "@igniteui/cli-core": "~14.3.18-beta.0",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.1.14316",
+  "version": "19.1.14318-beta.0",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.1.14316",
-    "@igniteui/cli-core": "~14.3.16",
+    "@igniteui/angular-templates": "~19.1.14318-beta.0",
+    "@igniteui/cli-core": "~14.3.18-beta.0",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.1.14318-beta.0",
+  "version": "19.1.14318-beta.1",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.1.14318-beta.0",
-    "@igniteui/cli-core": "~14.3.18-beta.0",
+    "@igniteui/angular-templates": "~19.1.14318-beta.1",
+    "@igniteui/cli-core": "~14.3.18-beta.1",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.1.14318-beta.1",
+  "version": "19.1.14318-beta.2",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.1.14318-beta.1",
-    "@igniteui/cli-core": "~14.3.18-beta.1",
+    "@igniteui/angular-templates": "~19.1.14318-beta.2",
+    "@igniteui/cli-core": "~14.3.18-beta.2",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.1.1438-beta.3",
+  "version": "19.1.14318-beta.4",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.1.1438-beta.3",
-    "@igniteui/cli-core": "~14.3.8-beta.3",
+    "@igniteui/angular-templates": "~19.1.14318-beta.4",
+    "@igniteui/cli-core": "~14.3.18-beta.4",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "19.1.14318-beta.2",
+  "version": "19.1.1438-beta.3",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~19.1.14318-beta.2",
-    "@igniteui/cli-core": "~14.3.18-beta.2",
+    "@igniteui/angular-templates": "~19.1.1438-beta.3",
+    "@igniteui/cli-core": "~14.3.8-beta.3",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
Remove the step in github pages yml for adding the ig-theme, because we’ll use the import inline css syntax for the styles. The changes will be handled in the CodeGen, so no further modifications are needed here.