### PR TITLE
Add test setup file for angular standalone

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteui-cli",
-  "version": "14.5.6-beta.2",
+  "version": "14.5.5",
   "description": "CLI tool for creating Ignite UI projects",
   "keywords": [
     "CLI",
@@ -76,8 +76,8 @@
     "all": true
   },
   "dependencies": {
-    "@igniteui/angular-templates": "~20.0.1456-beta.2",
-    "@igniteui/cli-core": "~14.5.6-beta.2",
+    "@igniteui/angular-templates": "~20.0.1455",
+    "@igniteui/cli-core": "~14.5.5",
     "@inquirer/prompts": "^5.4.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/cli-core",
-  "version": "14.5.6-beta.2",
+  "version": "14.5.5",
   "description": "Base types and functionality for Ignite UI CLI",
   "repository": {
     "type": "git",

--- a/packages/igx-templates/package.json
+++ b/packages/igx-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-templates",
-  "version": "20.0.1456-beta.2",
+  "version": "20.0.1455",
   "description": "Templates for Ignite UI for Angular projects and components",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
   "author": "Infragistics",
   "license": "MIT",
   "dependencies": {
-    "@igniteui/cli-core": "~14.5.6-beta.2",
+    "@igniteui/cli-core": "~14.5.5",
     "typescript": "~5.5.4"
   }
 }

--- a/packages/ng-schematics/package.json
+++ b/packages/ng-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniteui/angular-schematics",
-  "version": "20.0.1456-beta.2",
+  "version": "20.0.1455",
   "description": "Ignite UI for Angular Schematics for ng new and ng generate",
   "repository": {
     "type": "git",
@@ -20,8 +20,8 @@
   "dependencies": {
     "@angular-devkit/core": "^19.0.0",
     "@angular-devkit/schematics": "^19.0.0",
-    "@igniteui/angular-templates": "~20.0.1456-beta.2",
-    "@igniteui/cli-core": "~14.5.6-beta.2",
+    "@igniteui/angular-templates": "~20.0.1455",
+    "@igniteui/cli-core": "~14.5.5",
     "@schematics/angular": "~19.0.0",
     "minimatch": "^10.0.1",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
Add test setup file in angular standalone template for preventing the "Injector has already been destroyed" error by keeping the Angular TestBed alive across tests.

