### PR TITLE
fix(ng): move eslint eqeqeq rule

### DIFF
--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/eslint.config.mjs
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/eslint.config.mjs
@@ -29,13 +29,13 @@ export default [
   },
   {
     files: ['**/*.html'],
-    rules: {
-      eqeqeq: 'off'
-    },
     languageOptions: {
       parser: '@angular-eslint/template-parser'
     },
-    ...compat.extends('plugin:@angular-eslint/template/recommended')[0]
+    ...compat.extends('plugin:@angular-eslint/template/recommended')[0],
+    rules: {
+      eqeqeq: 'off'
+    },
   },
   {
     files: ['**/*.ts'],


### PR DESCRIPTION
Moved the rules section to the end of the configuration object so it overrides any rules from the extended configuration.
This ensures that `'@angular-eslint/template/eqeqeq': 'off'` takes precedence over the default rule from `plugin:@angular-eslint/template/recommended`.

