### PR TITLE
ci: temporarily disable spec file linting

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/files/eslint.config.mjs
+++ b/packages/igx-templates/igx-ts/projects/_base/files/eslint.config.mjs
@@ -5,7 +5,6 @@ const compat = new FlatCompat();
 export default [
   {
     files: ['**/*.ts', '**/*.tsx'],
-    ignores: ['**/*.spec.ts'],
     languageOptions: {
       parser: await import('@typescript-eslint/parser'),
       parserOptions: {


### PR DESCRIPTION
Temporarily disable `.spec` files from linting, until proper esling is configured: https://github.com/IgniteUI/igniteui-cli/issues/1292

