### PR TITLE
Fix failing angular standalone tests

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/files/package.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/package.json
@@ -49,9 +49,7 @@
       "@angular/common": "^21.0.0",
       "@angular/compiler": "^21.0.0",
       "rxjs": "~7.8.1"
-    },
-    "glob": "^11.0.3",
-    "rimraf": "^6.0.1"
+    }
   },
   "devDependencies": {
     "@angular/build": "~21.0.0",


### PR DESCRIPTION
Remove glob and rimraf from angular standalone package.json to fix failing karma.

