### PR TITLE
fix(angular): increase maximum error budget

### DIFF
--- a/packages/cli/templates/angular/ig-ts/projects/empty/files/angular.json
+++ b/packages/cli/templates/angular/ig-ts/projects/empty/files/angular.json
@@ -37,7 +37,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "10mb",
-                  "maximumError": "20mb"
+                  "maximumError": "40mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/packages/igx-templates/igx-ts-legacy/projects/_base/files/angular.json
+++ b/packages/igx-templates/igx-ts-legacy/projects/_base/files/angular.json
@@ -48,7 +48,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "5mb",
-                  "maximumError": "10mb"
+                  "maximumError": "40mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/packages/igx-templates/igx-ts/projects/_base/files/angular.json
+++ b/packages/igx-templates/igx-ts/projects/_base/files/angular.json
@@ -47,7 +47,7 @@
 								{
 									"type": "initial",
 									"maximumWarning": "5mb",
-									"maximumError": "10mb"
+									"maximumError": "40mb"
 								},
 								{
 									"type": "anyComponentStyle",


### PR DESCRIPTION
Closes #[2197](https://github.com/IgniteUI/CodeGen/issues/2197)

Additional information related to this pull request: The maximum error budget is increased from 10mb to 40mb.

