### PR TITLE
fix(commands,list): do not use `this` in handler

### DIFF
--- a/packages/cli/lib/commands/doc.ts
+++ b/packages/cli/lib/commands/doc.ts
@@ -27,7 +27,7 @@ const doc: DocCommandType = {
 		if (!argv.term) {
 			const answer = await PromptSession.chooseTerm();
 			argv.term = answer;
-			await this.handler(argv);
+			await doc.handler(argv);
 		} else if (!Util.isAlphanumericExt(argv.term)) {
 			return Util.error(`The search term '${argv.term}' is not valid.` + "\n" +
 			"Name should start with a letter and can also contain numbers, dashes and spaces.",

--- a/packages/cli/lib/commands/list.ts
+++ b/packages/cli/lib/commands/list.ts
@@ -40,7 +40,7 @@ const command: CommandType = {
 		const templatesByGroup = [];
 		const controlGroups: string[] = [];
 
-		const framework: Framework = this.templateManager.getFrameworkById(argv.framework);
+		const framework: Framework = command.templateManager.getFrameworkById(argv.framework);
 		if (!framework) {
 			return Util.error("Wrong framework provided", "red");
 		}

--- a/packages/cli/lib/commands/types.ts
+++ b/packages/cli/lib/commands/types.ts
@@ -70,7 +70,7 @@ export interface CommandType extends CommandModule<{}, any> {
 	templateManager?: TemplateManager;
 
 	/** Handler function that will be called by yargs after the command line has been parsed. */
-	handler(argv: ArgumentsCamelCase<PositionalArgs>);
+	handler(/** do not use `this` in handler */this: void, argv: ArgumentsCamelCase<PositionalArgs>);
 }
 
 export interface NewCommandType extends CommandType {


### PR DESCRIPTION
Fixes #1493

Yargs internally transforms the command configuration object and calls the handler on that, which makes `this` not the same object anymore and thus lacking the initialized template manager. Added a type to prevent use in future.