### PR TITLE
fix(angular): add missing providers

### DIFF
--- a/packages/igx-templates/igx-ts/projects/_base/files/src/app/app.config.ts
+++ b/packages/igx-templates/igx-ts/projects/_base/files/src/app/app.config.ts
@@ -1,11 +1,11 @@
-import { ApplicationConfig, ErrorHandler, EnvironmentProviders, Provider, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { ApplicationConfig, EnvironmentProviders, ErrorHandler, Provider, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
 import { BrowserModule, HammerModule } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 
+import { environment } from '../environments/environment';
 import { routes } from './app.routes';
 import { GlobalErrorHandlerService } from './error-routing/error/global-error-handler.service';
-import { environment } from '../environments/environment';
 
 // provide the HAMMER_GESTURE_CONFIG token
 // to override the default settings of the HammerModule

--- a/packages/igx-templates/igx-ts/projects/_base_with_home/files/src/app/app.config.ts
+++ b/packages/igx-templates/igx-ts/projects/_base_with_home/files/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { ApplicationConfig, EnvironmentProviders, Provider, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
 import { BrowserModule, HammerModule } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 

--- a/packages/igx-templates/igx-ts/projects/empty/files/src/app/app.config.ts
+++ b/packages/igx-templates/igx-ts/projects/empty/files/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { ApplicationConfig, EnvironmentProviders, Provider, importProvidersFrom, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
 import { BrowserModule, HammerModule } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 


### PR DESCRIPTION
Add missing providers in the angular base and in the empty template app configs.

Closes #1496 

