### PR TITLE
fix(ai-config): add igniteui-webcomponents skills w/o framework config

### DIFF
--- a/packages/core/update/package-resolve.ts
+++ b/packages/core/update/package-resolve.ts
@@ -41,6 +41,7 @@ export const NPM_REACT_SPREADSHEET_CHART_ADAPTER = "igniteui-react-spreadsheet-c
 export const FEED_REACT_SPREADSHEET_CHART_ADAPTER = "@infragistics/igniteui-react-spreadsheet-chart-adapter";
 
 // webcomponents
+export const NPM_WEBCOMPONENTS = "igniteui-webcomponents";
 export const NPM_WEBCOMPONENTS_CHARTS = "igniteui-webcomponents-charts";
 export const FEED_WEBCOMPONENTS_CHARTS = "@infragistics/igniteui-webcomponents-charts";
 export const NPM_WEBCOMPONENTS_CORE = "igniteui-webcomponents-core";

--- a/packages/core/util/ai-skills.ts
+++ b/packages/core/util/ai-skills.ts
@@ -3,7 +3,7 @@ import { App } from "./App";
 import { IFileSystem, FS_TOKEN } from "../types/FileSystem";
 import { ProjectConfig } from "./ProjectConfig";
 import { Util } from "./Util";
-import { NPM_ANGULAR, NPM_REACT, resolvePackage, UPGRADEABLE_PACKAGES } from "../update/package-resolve";
+import { NPM_ANGULAR, NPM_REACT, NPM_WEBCOMPONENTS, resolvePackage, UPGRADEABLE_PACKAGES } from "../update/package-resolve";
 
 const CLAUDE_SKILLS_DIR = ".claude/skills";
 
@@ -23,15 +23,16 @@ function resolveSkillsRoots(): string[] {
 	} catch { /* config not readable – fall through to scan all */ }
 
 	const allPkgKeys = Object.keys(UPGRADEABLE_PACKAGES);
-	let candidates: string[];
+	let candidates = new Set<string>();
 	if (framework === "angular") {
-		candidates = [NPM_ANGULAR];
+		candidates.add(NPM_ANGULAR);
 	} else if (framework === "react") {
-		candidates = [NPM_REACT];
+		candidates.add(NPM_REACT);
 	} else if (framework === "webcomponents") {
-		candidates = allPkgKeys.filter(k => k.startsWith("igniteui-webcomponents"));
+		candidates.add(NPM_WEBCOMPONENTS);
 	} else {
-		candidates = allPkgKeys;
+		// NPM_REACT and NPM_WEBCOMPONENTS are OSS-only and not in UPGRADEABLE_PACKAGES, so add them explicitly
+		candidates = new Set([...allPkgKeys, NPM_REACT, NPM_WEBCOMPONENTS]);
 	}
 
 	for (const pkg of candidates) {

--- a/spec/unit/ai-skills-spec.ts
+++ b/spec/unit/ai-skills-spec.ts
@@ -166,7 +166,7 @@ describe("Unit - copyAISkillsToProject", () => {
 
 	describe("WebComponents framework", () => {
 		it("should copy skills from igniteui-webcomponents into .claude/skills/", async () => {
-			const wcPkg = "igniteui-webcomponents-core";
+			const wcPkg = "igniteui-webcomponents";
 			const dir = skillsDir(wcPkg);
 			const file = skillFile(wcPkg, "webcomponents.md");
 			const content = "# Ignite UI WebComponents skills";
@@ -231,6 +231,56 @@ describe("Unit - copyAISkillsToProject", () => {
 			// With multiple roots, the dest path is prefixed; angular is the only root found here
 			// but since we scan ALL packages and only one directory exists, roots.length === 1 → no prefix
 			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/angular.md", "skill content");
+		});
+
+		it("should also scan igniteui-react in the fallback", async () => {
+			const reactPkg = "igniteui-react";
+			const dir = skillsDir(reactPkg);
+			const file = skillFile(reactPkg, "overview.md");
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.returnValue(false),
+				readFile: jasmine.createSpy("readFile").and.returnValue("react skill content"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === dir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === dir ? [file] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+
+			await copyAISkillsToProject();
+
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/overview.md", "react skill content");
+		});
+
+		it("should also scan igniteui-webcomponents in the fallback", async () => {
+			const wcPkg = "igniteui-webcomponents";
+			const dir = skillsDir(wcPkg);
+			const file = skillFile(wcPkg, "webcomponents.md");
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.returnValue(false),
+				readFile: jasmine.createSpy("readFile").and.returnValue("wc skill content"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === dir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === dir ? [file] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+
+			await copyAISkillsToProject();
+
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/webcomponents.md", "wc skill content");
 		});
 	});
 


### PR DESCRIPTION
## Description

When calling `ig ai-config` in a project without cli config JSON, the fallback fails to copy `igniteui-webcomponents` skills (first attempt), but does copy `igniteui-react` if added, since that's in the upgradable list (which it shouldn't be anymore too). Added explicitly those packages so they are picked up.

<img width="1722" height="972" alt="image" src="https://github.com/user-attachments/assets/9fd8465f-def2-420c-9bfa-7e39423df172" />


## Related Issue

Closes #<issue-number>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [ ] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [ ] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [ ] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [ ] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
