### PR TITLE
docs(agents): point React and Web Components agents.md to package-aware references

### DIFF
--- a/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
@@ -109,4 +109,8 @@ You are an expert in building front-end web applications with React with deep kn
 ## UI Components
 
 - Use `igniteui-react`.
+- Use `igniteui-react-grids` for advanced grids.
+- Use `igniteui-react` and `igniteui-grid-lite` for Grid Lite; import from `igniteui-react/grid-lite`.
+- Use `igniteui-react-charts`, `igniteui-react-gauges`, and `igniteui-react-maps` for charts, gauges, and maps.
 - For package-specific components such as grids, Grid Lite, charts, gauges, and maps, do not assume they come from `igniteui-react`; follow `.claude/skills/igniteui-react-components/SKILL.md` to choose the correct package and imports.
+- If the required Ignite UI package is not present in `package.json`, add or install the correct dependency first.

--- a/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
@@ -109,3 +109,4 @@ You are an expert in building front-end web applications with React with deep kn
 ## UI Components
 
 - Use `igniteui-react`.
+- For package-specific components such as grids, Grid Lite, charts, gauges, and maps, do not assume they come from `igniteui-react`; follow `.claude/skills/igniteui-react-components` to choose the correct package and imports.

--- a/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/react/igr-ts/projects/_base/files/AGENTS.md
@@ -109,4 +109,4 @@ You are an expert in building front-end web applications with React with deep kn
 ## UI Components
 
 - Use `igniteui-react`.
-- For package-specific components such as grids, Grid Lite, charts, gauges, and maps, do not assume they come from `igniteui-react`; follow `.claude/skills/igniteui-react-components` to choose the correct package and imports.
+- For package-specific components such as grids, Grid Lite, charts, gauges, and maps, do not assume they come from `igniteui-react`; follow `.claude/skills/igniteui-react-components/SKILL.md` to choose the correct package and imports.

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
@@ -31,4 +31,4 @@ You are an expert in building front-end web applications. You have a strong unde
 ## UI Components
 
 - Use `igniteui-webcomponents`.
-- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; follow `.claude/skills/igniteui-wc-choose-components/SKILL.md` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md` for setup.
+- For package-specific components such as charts, advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; follow `.claude/skills/igniteui-wc-choose-components/SKILL.md` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md` for setup.

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
@@ -31,4 +31,9 @@ You are an expert in building front-end web applications. You have a strong unde
 ## UI Components
 
 - Use `igniteui-webcomponents`.
+- Use `igniteui-webcomponents-charts` for charts and data visualization.
+- Use `igniteui-webcomponents-grids` for advanced grids.
+- Use `igniteui-grid-lite` for Grid Lite.
+- Use `igniteui-dockmanager` for Dock Manager.
 - For package-specific components such as charts, advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; follow `.claude/skills/igniteui-wc-choose-components/SKILL.md` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md` for setup.
+- If the required Ignite UI package is not present in `package.json`, add or install the correct dependency first.

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
@@ -31,4 +31,4 @@ You are an expert in building front-end web applications. You have a strong unde
 ## UI Components
 
 - Use `igniteui-webcomponents`.
-- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; use [` .claude/skills/igniteui-wc-choose-components/SKILL.md`](.claude/skills/igniteui-wc-choose-components/SKILL.md) to choose the correct package and [` .claude/skills/igniteui-wc-integrate-with-framework/SKILL.md`](.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md) for setup.
+- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; follow `.claude/skills/igniteui-wc-choose-components/SKILL.md` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md` for setup.

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
@@ -31,3 +31,4 @@ You are an expert in building front-end web applications. You have a strong unde
 ## UI Components
 
 - Use `igniteui-webcomponents`.
+- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; use `.claude/skills/igniteui-wc-choose-components` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework` for setup.

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/files/AGENTS.md
@@ -31,4 +31,4 @@ You are an expert in building front-end web applications. You have a strong unde
 ## UI Components
 
 - Use `igniteui-webcomponents`.
-- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; use `.claude/skills/igniteui-wc-choose-components` to choose the correct package and `.claude/skills/igniteui-wc-integrate-with-framework` for setup.
+- For package-specific components such as advanced grids, Grid Lite, and Dock Manager, do not assume they come from `igniteui-webcomponents`; use [` .claude/skills/igniteui-wc-choose-components/SKILL.md`](.claude/skills/igniteui-wc-choose-components/SKILL.md) to choose the correct package and [` .claude/skills/igniteui-wc-integrate-with-framework/SKILL.md`](.claude/skills/igniteui-wc-integrate-with-framework/SKILL.md) for setup.


### PR DESCRIPTION
## Description

Updates the generated React and Web Components AGENTS.md files to direct AI agents to the correct package-aware skills. This keeps the template entry instructions minimal while aligning them better with the Angular flow.

## Related Issue

Closes #1633

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [ ] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [ ] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [ ] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [x] My changes do not introduce new warnings or errors
