### PR TITLE
fix(execute): ensure correct CLI loading based on version mismatch

### DIFF
--- a/packages/cli/bin/execute.js
+++ b/packages/cli/bin/execute.js
@@ -14,8 +14,14 @@ resolve("igniteui-cli", { basedir: process.cwd() }, function (err, res) {
 		const globalVersion = require(path.join(__dirname, "../package.json"))["version"];
 		if (globalVersion !== localVersion) {
 			console.log("Different igniteui-cli global and local version");
+			if (args[0] === "ai-config") {
+				cli = require("../lib/cli");
+			} else {
+				cli = require(res);
+			}
+		} else {
+			cli = require(res);
 		}
-		cli = require(res);
 	} else {
 		cli = require("../lib/cli");
 	}

--- a/packages/cli/bin/execute.js
+++ b/packages/cli/bin/execute.js
@@ -13,12 +13,11 @@ resolve("igniteui-cli", { basedir: process.cwd() }, function (err, res) {
 		const localVersion = require(path.join(process.cwd(), "node_modules/igniteui-cli/package.json"))["version"];
 		const globalVersion = require(path.join(__dirname, "../package.json"))["version"];
 		if (globalVersion !== localVersion) {
-			console.log("Different igniteui-cli global and local version");
-			if (args[0] === "ai-config") {
-				cli = require("../lib/cli");
-			} else {
-				cli = require(res);
-			}
+			console.log("Different igniteui-cli global and local version");			
+		}
+		
+		if (args[0] === "ai-config") {
+			cli = require("../lib/cli");
 		} else {
 			cli = require(res);
 		}

--- a/packages/cli/bin/execute.js
+++ b/packages/cli/bin/execute.js
@@ -14,8 +14,7 @@ resolve("igniteui-cli", { basedir: process.cwd() }, function (err, res) {
 		const globalVersion = require(path.join(__dirname, "../package.json"))["version"];
 		if (globalVersion !== localVersion) {
 			console.log("Different igniteui-cli global and local version");			
-		}
-		
+		}		
 		if (args[0] === "ai-config") {
 			cli = require("../lib/cli");
 		} else {


### PR DESCRIPTION
## Description

When executing ai-config command and there is mismatch in local and global version we always flavor the global one similar to Angular CLI.

## Related Issue

Closes #1631

## Type of Change

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [ ] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [ ] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [ ] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [ ] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
