### PR TITLE
Update `ai-config` skills copy messaging w/ up-to-date/failed, don't call in step-by-step

### DIFF
--- a/packages/cli/lib/PromptSession.ts
+++ b/packages/cli/lib/PromptSession.ts
@@ -105,7 +105,8 @@ export class PromptSession extends BasePromptSession {
 	}
 
 	protected async configureAI(): Promise<void> {
-		aiConfigure();
+		// skip adding skills since those are baked into the project template atm:
+		aiConfigure(false);
 	}
 
 	/**

--- a/packages/cli/lib/commands/ai-config.ts
+++ b/packages/cli/lib/commands/ai-config.ts
@@ -78,9 +78,11 @@ export function configureSkills(): void {
 	}
 }
 
-export function configure(fileSystem: IFileSystem = new FsFileSystem()): void {
-	configureMCP(fileSystem);
-	configureSkills();
+export function configure(skills = true): void {
+	configureMCP();
+	if (skills) {
+		configureSkills();
+	}
 }
 
 const command: CommandModule = {

--- a/packages/cli/lib/commands/ai-config.ts
+++ b/packages/cli/lib/commands/ai-config.ts
@@ -65,11 +65,16 @@ export function configureMCP(fileSystem: IFileSystem = new FsFileSystem()): void
 
 export function configureSkills(): void {
 	const result = copyAISkillsToProject();
-	if (result === "copied") {
-		Util.log(Util.greenCheck() + " AI skills added to the project.");
-	} else {
+	if (result.found === 0) {
 		Util.warn("No AI skill files found. Make sure packages are installed (npm install) " +
-			"and your Ignite UI package includes a skills/ directory.", "yellow");
+			"and your Ignite UI packages are up-to-date.", "yellow");
+	} else if (result.failed > 0) {
+		Util.warn(`Failed to write ${result.failed} skill file(s) out of ${result.found}.`, "yellow");
+	} else if (result.skipped === result.found) {
+		Util.log("Everything is already up-to-date.");
+	} else {
+		const written = result.found - result.skipped;
+		Util.log(Util.greenCheck() + ` ${written} AI skill file(s) created or updated.`);
 	}
 }
 

--- a/packages/core/util/ai-skills.ts
+++ b/packages/core/util/ai-skills.ts
@@ -7,6 +7,12 @@ import { NPM_ANGULAR, NPM_REACT, NPM_WEBCOMPONENTS, resolvePackage, UPGRADEABLE_
 
 const CLAUDE_SKILLS_DIR = ".claude/skills";
 
+export interface AISkillsCopyResult {
+	found: number;
+	skipped: number;
+	failed: number;
+}
+
 /**
  * Returns the list of 'skills/' directory paths found in installed
  * Ignite UI packages that are relevant to the project's detected framework.
@@ -50,22 +56,23 @@ function resolveSkillsRoots(): string[] {
  * Copies skill files from the installed Ignite UI package(s) into .claude/skills/.
  * Works with both real FS (CLI) and virtual Tree FS (schematics) through IFileSystem.
  */
-export function copyAISkillsToProject(): "copied" | "no-source" {
+export function copyAISkillsToProject(): AISkillsCopyResult {
+	const result: AISkillsCopyResult = { found: 0, skipped: 0, failed: 0 };
 	const fs = App.container.get<IFileSystem>(FS_TOKEN);
 	const skillsRoots = resolveSkillsRoots();
 
 	if (!skillsRoots.length) {
-		return "no-source";
+		return result;
 	}
 
 	const multiRoot = skillsRoots.length > 1;
-	let copied = false;
 
 	for (const skillsRoot of skillsRoots) {
 		const rawPaths = fs.glob(skillsRoot, "**/*");
 		const pkgDirName = multiRoot ? path.basename(path.dirname(skillsRoot)) : "";
 
 		for (const p of rawPaths) {
+			result.found++;
 			// Normalize to posix and strip leading '/' so path.posix.relative works
 			// across both FsFileSystem (relative paths) and NgTreeFileSystem (tree-rooted paths)
 			const normP = p.replace(/\\/g, "/").replace(/^\//, "");
@@ -75,10 +82,25 @@ export function copyAISkillsToProject(): "copied" | "no-source" {
 				? `${CLAUDE_SKILLS_DIR}/${pkgDirName}/${rel}`
 				: `${CLAUDE_SKILLS_DIR}/${rel}`;
 
-			fs.writeFile(dest, fs.readFile(p));
-			Util.log(`${Util.greenCheck()} Created ${dest}`);
-			copied = true;
+			const newContent = fs.readFile(p);
+			try {
+				if (fs.fileExists(dest)) {
+					const existingContent = fs.readFile(dest);
+					if (existingContent === newContent) {
+						result.skipped++;
+						continue;
+					}
+					fs.writeFile(dest, newContent);
+					Util.log(`${Util.greenCheck()} Updated ${dest}`);
+				} else {
+					fs.writeFile(dest, newContent);
+					Util.log(`${Util.greenCheck()} Created ${dest}`);
+				}
+			} catch {
+				result.failed++;
+			}
 		}
 	}
-	return copied ? "copied" : "no-source";
+
+	return result;
 }

--- a/spec/unit/PromptSession-spec.ts
+++ b/spec/unit/PromptSession-spec.ts
@@ -501,6 +501,7 @@ describe("Unit - PromptSession", () => {
 		expect(PackageManager.flushQueue).toHaveBeenCalledWith(true);
 		expect(start.start).toHaveBeenCalledTimes(1);
 		expect(aiConfig.configure).toHaveBeenCalledTimes(1);
+		expect(aiConfig.configure).toHaveBeenCalledWith(false);
 		expect(add.addTemplate).toHaveBeenCalledTimes(1);
 		expect(InquirerWrapper.input).toHaveBeenCalledWith({
 			type: "input",
@@ -579,6 +580,7 @@ describe("Unit - PromptSession", () => {
 		expect(PackageManager.flushQueue).toHaveBeenCalledWith(true);
 		expect(start.start).toHaveBeenCalledTimes(1);
 		expect(aiConfig.configure).toHaveBeenCalledTimes(1);
+		expect(aiConfig.configure).toHaveBeenCalledWith(false);
 		expect(Util.getAvailableName).toHaveBeenCalledTimes(1);
 		expect(add.addTemplate).toHaveBeenCalledTimes(1);
 		expect(add.addTemplate).toHaveBeenCalledWith("Custom Template Name", mockSelectedTemplate);
@@ -704,6 +706,7 @@ describe("Unit - PromptSession", () => {
 		expect(PackageManager.flushQueue).toHaveBeenCalledWith(true);
 		expect(start.start).toHaveBeenCalledTimes(1);
 		expect(aiConfig.configure).toHaveBeenCalledTimes(1);
+		expect(aiConfig.configure).toHaveBeenCalledWith(false);
 		expect(add.addTemplate).toHaveBeenCalledTimes(1);
 		expect(InquirerWrapper.checkbox).toHaveBeenCalledWith({
 			type: "checkbox",

--- a/spec/unit/ai-config-spec.ts
+++ b/spec/unit/ai-config-spec.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
-import { App, FS_TOKEN, GoogleAnalytics, IFileSystem, Util } from "@igniteui/cli-core";
-import { configureMCP } from "../../packages/cli/lib/commands/ai-config";
+import { App, Config, FS_TOKEN, GoogleAnalytics, IFileSystem, ProjectConfig, Util } from "@igniteui/cli-core";
+import { configureMCP, configureSkills } from "../../packages/cli/lib/commands/ai-config";
 import * as aiConfig  from "../../packages/cli/lib/commands/ai-config";
 
 const IGNITEUI_SERVER_KEY = "igniteui-cli";
@@ -113,6 +113,118 @@ describe("Unit - ai-config command", () => {
 			expect((config.servers as any)["other-server"]).toEqual(thirdPartyServer);
 			expect((config.servers as any)[IGNITEUI_SERVER_KEY]).toEqual(igniteuiServer);
 			expect((config.servers as any)[IGNITEUI_THEMING_SERVER_KEY]).toEqual(igniteuiThemingServer);
+		});
+	});
+
+	describe("configureSkills", () => {
+		const angularSkillsDir = "node_modules/igniteui-angular/skills";
+
+		beforeEach(() => {
+			spyOn(Util, "warn");
+		});
+
+		function setupAngularConfig() {
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+		}
+
+		it("warns when no skill files are found", () => {
+			const mockFs: IFileSystem = {
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue(""),
+				writeFile: jasmine.createSpy("writeFile"),
+				directoryExists: jasmine.createSpy("directoryExists").and.returnValue(false),
+				glob: jasmine.createSpy("glob").and.returnValue([])
+			} as unknown as IFileSystem;
+
+			spyOn(App.container, "get").and.returnValue(mockFs);
+			setupAngularConfig();
+
+			configureSkills();
+
+			expect(Util.warn).toHaveBeenCalledWith(jasmine.stringContaining("No AI skill files found"), "yellow");
+			expect(Util.log).not.toHaveBeenCalled();
+		});
+
+		it("warns with failure count when some writes fail", () => {
+			const skillFile = `${angularSkillsDir}/angular.md`;
+			const mockFs: IFileSystem = {
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue("skill content"),
+				writeFile: jasmine.createSpy("writeFile").and.throwError("EACCES: permission denied"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === angularSkillsDir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === angularSkillsDir ? [skillFile] : []
+				)
+			} as unknown as IFileSystem;
+
+			spyOn(App.container, "get").and.returnValue(mockFs);
+			setupAngularConfig();
+
+			configureSkills();
+
+			expect(Util.warn).toHaveBeenCalledWith(jasmine.stringContaining("Failed to write 1 skill file(s) out of 1"), "yellow");
+			expect(Util.log).not.toHaveBeenCalled();
+		});
+
+		it("logs up-to-date when all files are already current", () => {
+			const skillFile = `${angularSkillsDir}/angular.md`;
+			const destFile = ".claude/skills/angular.md";
+			const content = "# Ignite UI skills";
+			const mockFs: IFileSystem = {
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json" || p === destFile
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue(content),
+				writeFile: jasmine.createSpy("writeFile"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === angularSkillsDir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === angularSkillsDir ? [skillFile] : []
+				)
+			} as unknown as IFileSystem;
+
+			spyOn(App.container, "get").and.returnValue(mockFs);
+			setupAngularConfig();
+
+			configureSkills();
+
+			expect(Util.log).toHaveBeenCalledWith(jasmine.stringContaining("already up-to-date"));
+			expect(Util.warn).not.toHaveBeenCalled();
+		});
+
+		it("logs created/updated count when skills are written successfully", () => {
+			const skillFile = `${angularSkillsDir}/angular.md`;
+			const mockFs: IFileSystem = {
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue("skill content"),
+				writeFile: jasmine.createSpy("writeFile"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === angularSkillsDir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === angularSkillsDir ? [skillFile] : []
+				)
+			} as unknown as IFileSystem;
+
+			spyOn(App.container, "get").and.returnValue(mockFs);
+			setupAngularConfig();
+
+			configureSkills();
+
+			expect(Util.log).toHaveBeenCalledWith(jasmine.stringContaining("1 AI skill file(s) created or updated"));
+			expect(Util.warn).not.toHaveBeenCalled();
 		});
 	});
 

--- a/spec/unit/ai-skills-spec.ts
+++ b/spec/unit/ai-skills-spec.ts
@@ -1,4 +1,4 @@
-import { App, Config, copyAISkillsToProject, IFileSystem, ProjectConfig } from "@igniteui/cli-core";
+import { App, Config, copyAISkillsToProject, IFileSystem, ProjectConfig, Util } from "@igniteui/cli-core";
 
 function skillsDir(pkgName: string) {
 	return `node_modules/${pkgName}/skills`;
@@ -20,6 +20,11 @@ function makeFs(overrides: Partial<IFileSystem> = {}): IFileSystem {
 }
 
 describe("Unit - copyAISkillsToProject", () => {
+	beforeEach(() => {
+		spyOn(Util, "log");
+		spyOn(Util, "greenCheck").and.returnValue("✓");
+	});
+
 	describe("Angular framework", () => {
 		it("should copy skills from igniteui-angular into .claude/skills/", async () => {
 			const angularSkillsDir = skillsDir("igniteui-angular");
@@ -105,7 +110,7 @@ describe("Unit - copyAISkillsToProject", () => {
 				}),
 				readFile: jasmine.createSpy("readFile").and.callFake((p: string) => {
 					if (p === skillFilePath) return newContent;
-					return "";
+					return ""; // dest has different (older) content
 				}),
 				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
 					p === angularSkillsDir
@@ -123,6 +128,42 @@ describe("Unit - copyAISkillsToProject", () => {
 			await copyAISkillsToProject();
 
 			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/angular.md", newContent);
+			expect(Util.log).toHaveBeenCalledWith(jasmine.stringContaining("Updated .claude/skills/angular.md"));
+		});
+
+		it("should not write when destination content is already up-to-date", async () => {
+			const angularSkillsDir = skillsDir("igniteui-angular");
+			const skillFilePath = skillFile("igniteui-angular", "angular.md");
+			const existingContent = "# Ignite UI for Angular skills";
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) => {
+					if (p === "ignite-ui-cli.json") return true;
+					if (p === ".claude/skills/angular.md") return true;
+					return false;
+				}),
+				readFile: jasmine.createSpy("readFile").and.returnValue(existingContent),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === angularSkillsDir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === angularSkillsDir ? [skillFilePath] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+
+			const result = await copyAISkillsToProject();
+
+			expect(fs.writeFile).not.toHaveBeenCalled();
+			expect(result.found).toBe(1);
+			expect(result.skipped).toBe(1);
+			expect(result.failed).toBe(0);
+			expect(Util.log).not.toHaveBeenCalled(); // no per-file Created/Updated logs emitted
 		});
 	});
 
@@ -328,6 +369,120 @@ describe("Unit - copyAISkillsToProject", () => {
 			await copyAISkillsToProject();
 
 			expect(fs.writeFile).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Error handling", () => {
+		it("should increment failed when writeFile throws creating a new file", async () => {
+			const pkg = "igniteui-angular";
+			const dir = skillsDir(pkg);
+			const file = skillFile(pkg, "angular.md");
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) => {
+					if (p === "ignite-ui-cli.json") return true;
+					return false; // dest does not exist
+				}),
+				readFile: jasmine.createSpy("readFile").and.returnValue("skill content"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === dir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === dir ? [file] : []
+				),
+				writeFile: jasmine.createSpy("writeFile").and.throwError("EACCES: permission denied")
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+
+			const result = await copyAISkillsToProject();
+
+			expect(result.found).toBe(1);
+			expect(result.skipped).toBe(0);
+			expect(result.failed).toBe(1);
+		});
+
+		it("should increment failed when writeFile throws updating an existing file", async () => {
+			const pkg = "igniteui-angular";
+			const dir = skillsDir(pkg);
+			const file = skillFile(pkg, "angular.md");
+			const destFile = ".claude/skills/angular.md";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) => {
+					if (p === "ignite-ui-cli.json") return true;
+					if (p === destFile) return true; // dest exists with different content
+					return false;
+				}),
+				readFile: jasmine.createSpy("readFile").and.callFake((p: string) => {
+					if (p === file) return "new content";
+					return "old content"; // dest has different content
+				}),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === dir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === dir ? [file] : []
+				),
+				writeFile: jasmine.createSpy("writeFile").and.throwError("EACCES: permission denied")
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+
+			const result = await copyAISkillsToProject();
+
+			expect(result.found).toBe(1);
+			expect(result.skipped).toBe(0);
+			expect(result.failed).toBe(1);
+		});
+
+		it("should report correct counts when some writes fail and some succeed", async () => {
+			const pkg = "igniteui-angular";
+			const dir = skillsDir(pkg);
+			const file1 = skillFile(pkg, "angular.md");
+			const file2 = skillFile(pkg, "components.md");
+
+			let writeCallCount = 0;
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) => {
+					if (p === "ignite-ui-cli.json") return true;
+					return false;
+				}),
+				readFile: jasmine.createSpy("readFile").and.returnValue("skill content"),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === dir
+				),
+				glob: jasmine.createSpy("glob").and.callFake((d: string) =>
+					d === dir ? [file1, file2] : []
+				),
+				writeFile: jasmine.createSpy("writeFile").and.callFake(() => {
+					writeCallCount++;
+					if (writeCallCount === 2) {
+						throw new Error("ENOSPC: no space left on device");
+					}
+				})
+			});
+
+			spyOn(App.container, "get").and.returnValue(fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+
+			const result = await copyAISkillsToProject();
+
+			expect(result.found).toBe(2);
+			expect(result.skipped).toBe(0);
+			expect(result.failed).toBe(1);
+			expect(fs.writeFile).toHaveBeenCalledTimes(2);
 		});
 	});
 


### PR DESCRIPTION
## Description

Update ai-config skills copy messaging to account for up-to-date files and possible failures.
Also made optional and skipped when called from Step-by-step, since the skills are in the template anyway ATM.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [x] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [x] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [x] I have tested my changes locally (`npm run test`)
- [x] I have built the project successfully (`npm run build`)
- [x] I have run the linter (`npm run lint`)
- [x] I have added/updated tests as needed
- [x] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
