### PR TITLE
feat(ai-config): skills fallback from project template

### DIFF
--- a/packages/cli/lib/cli.ts
+++ b/packages/cli/lib/cli.ts
@@ -1,4 +1,4 @@
-import { App, GoogleAnalytics, Util } from "@igniteui/cli-core";
+import { App, GoogleAnalytics, TEMPLATE_MANAGER, Util } from "@igniteui/cli-core";
 import yargs from "yargs";
 import {
 	add,
@@ -32,6 +32,8 @@ export async function run(args = null) {
 	App.initialize();
 
 	const templateManager = new TemplateManager();
+	// TODO: Refactor all code to use TemplateManager from the App container:
+	App.container.set(TEMPLATE_MANAGER, templateManager);
 
 	newCommand.addChoices(templateManager.getFrameworkIds());
 	newCommand.templateManager = templateManager;

--- a/packages/core/templates/BaseTemplateManager.ts
+++ b/packages/core/templates/BaseTemplateManager.ts
@@ -6,16 +6,18 @@ export abstract class BaseTemplateManager {
 	protected frameworks: Framework[] = [];
 
 	constructor(private templatesAbsPath: string) {
+		this.loadFrameworks();
+		this.loadExternalTemplates();
+	}
 
+	/** Populate `frameworks` prop with frameworks from templates */
+	protected loadFrameworks() {
 		// read dirs and push dir names into frameworks
 		const frameworks = Util.getDirectoryNames(this.templatesAbsPath);
 		// load and initialize templates
 		for (const framework of frameworks) {
 			this.frameworks.push(require(path.join(this.templatesAbsPath, framework)) as Framework);
 		}
-
-		// load external templates
-		this.loadExternalTemplates();
 	}
 
 	public getFrameworkIds(): string[] {

--- a/packages/core/util/GlobalConstants.ts
+++ b/packages/core/util/GlobalConstants.ts
@@ -2,6 +2,9 @@ import * as ts from 'typescript';
 import { EOL } from 'os';
 import { PropertyAssignment } from '../types';
 
+// tokens:
+export const TEMPLATE_MANAGER = "TEMPLATE_MANAGER";
+
 // TypeScript
 export const ROUTES_VARIABLE_NAME = 'routes';
 export const THEN_IDENTIFIER_NAME = 'then';

--- a/packages/core/util/ai-skills.ts
+++ b/packages/core/util/ai-skills.ts
@@ -1,11 +1,15 @@
 import * as path from "path";
+import type { BaseTemplateManager } from "../templates";
+import { FS_TOKEN, IFileSystem } from "../types/FileSystem";
+import { NPM_ANGULAR, NPM_REACT, NPM_WEBCOMPONENTS, resolvePackage, UPGRADEABLE_PACKAGES } from "../update/package-resolve";
 import { App } from "./App";
-import { IFileSystem, FS_TOKEN } from "../types/FileSystem";
+import { detectFrameworkFromPackageJson } from "./detect-framework";
+import { TEMPLATE_MANAGER } from "./GlobalConstants";
 import { ProjectConfig } from "./ProjectConfig";
 import { Util } from "./Util";
-import { NPM_ANGULAR, NPM_REACT, NPM_WEBCOMPONENTS, resolvePackage, UPGRADEABLE_PACKAGES } from "../update/package-resolve";
 
 const CLAUDE_SKILLS_DIR = ".claude/skills";
+const CLAUDE_SKILLS_DIR_TEMPLATE = "__dot__claude/skills";
 
 export interface AISkillsCopyResult {
 	found: number;
@@ -46,6 +50,22 @@ function resolveSkillsRoots(): string[] {
 		const skillsRoot = `node_modules/${resolved}/skills`;
 		if (fs.directoryExists(skillsRoot) && !roots.includes(skillsRoot)) {
 			roots.push(skillsRoot);
+		}
+	}
+
+	if (!roots.length) {
+		// if no root discovered, take the root from the appropriate project template files:
+		framework ??= detectFrameworkFromPackageJson();
+		if (framework) {
+			const templateManager = App.container.get<BaseTemplateManager>(TEMPLATE_MANAGER);
+			const projectLib = templateManager
+				.getFrameworkById(framework)?.projectLibraries[0]!;
+			const filePaths = projectLib?.getProject(projectLib.projectIds[0]).templatePaths ?? [];
+			roots.push(
+				...filePaths
+				.map((p) => path.join(p, CLAUDE_SKILLS_DIR_TEMPLATE))
+				.slice(0, 1),
+			);
 		}
 	}
 

--- a/packages/core/util/ai-skills.ts
+++ b/packages/core/util/ai-skills.ts
@@ -58,8 +58,7 @@ function resolveSkillsRoots(): string[] {
 		framework ??= detectFrameworkFromPackageJson();
 		if (framework) {
 			const templateManager = App.container.get<BaseTemplateManager>(TEMPLATE_MANAGER);
-			const projectLib = templateManager
-				.getFrameworkById(framework)?.projectLibraries[0]!;
+			const projectLib = templateManager?.getFrameworkById(framework)?.projectLibraries[0];
 			const filePaths = projectLib?.getProject(projectLib.projectIds[0]).templatePaths ?? [];
 			roots.push(
 				...filePaths

--- a/packages/core/util/detect-framework.ts
+++ b/packages/core/util/detect-framework.ts
@@ -1,0 +1,42 @@
+import { App } from "./App";
+import { IFileSystem, FS_TOKEN } from "../types/FileSystem";
+
+/**
+ * Attempts to detect the front-end framework by inspecting for well-known,
+ * always-present core framework packages in `dependencies`
+ * and `devDependencies` of `./package.json`.
+ *
+ * Detection rules (evaluated in priority order):
+ *  - "angular"      → `@angular/core` is present
+ *  - "react"        → `react` is present
+ *  - "webcomponents"→ fallback when neither of the above is found
+ *  - `null` if `package.json` is absent or cannot be parsed.
+ */
+export function detectFrameworkFromPackageJson(): "angular" | "react" | "webcomponents" | null {
+	const fs = App.container.get<IFileSystem>(FS_TOKEN);
+	if (!fs.fileExists("./package.json")) {
+		return null;
+	}
+
+	let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+	try {
+		pkg = JSON.parse(fs.readFile("./package.json"));
+	} catch {
+		return null;
+	}
+
+	const deps = new Set([
+		...Object.keys(pkg.dependencies ?? {}),
+		...Object.keys(pkg.devDependencies ?? {})
+	]);
+
+	if (deps.has("@angular/core")) {
+		return "angular";
+	}
+	if (deps.has("react")) {
+		return "react";
+	}
+
+	// for now assume webcomponents as default fallback
+	return "webcomponents";
+}

--- a/packages/core/util/index.ts
+++ b/packages/core/util/index.ts
@@ -1,4 +1,5 @@
 export * from './ai-skills';
+export * from './detect-framework';
 export * from './GoogleAnalytics';
 export * from './Util';
 export * from './ProjectConfig';

--- a/packages/ng-schematics/src/SchematicsTemplateManager.ts
+++ b/packages/ng-schematics/src/SchematicsTemplateManager.ts
@@ -5,11 +5,17 @@ import * as path from "path";
 export class SchematicsTemplateManager extends BaseTemplateManager {
 	constructor() {
 		super("");
+	}
+
+	protected override loadFrameworks() {
+		const projectLibrary = require("@igniteui/angular-templates").default as ProjectLibrary[];
 		this.frameworks.push({
 			id: "angular",
 			name: "angular",
-			projectLibraries: require("@igniteui/angular-templates").default as ProjectLibrary[]
+			projectLibraries: projectLibrary
 		});
+		// cache projectIds before swapping to virtFs; TODO: Refactor away folder imports legacy;
+		projectLibrary[0].projectIds;
 	}
 
 	protected loadFromConfig(filePath: string): Template {

--- a/packages/ng-schematics/src/cli-config/index.ts
+++ b/packages/ng-schematics/src/cli-config/index.ts
@@ -2,11 +2,12 @@ import * as ts from "typescript";
 import { DependencyNotFoundException } from "@angular-devkit/core";
 import { chain, FileDoesNotExistException, Rule, SchematicContext, Tree } from "@angular-devkit/schematics";
 import * as jsonc from "jsonc-parser";
-import { addClassToBody, copyAISkillsToProject, FormatSettings, NPM_ANGULAR, resolvePackage, TypeScriptAstTransformer, TypeScriptUtils } from "@igniteui/cli-core";
+import { addClassToBody, App, copyAISkillsToProject, FormatSettings, NPM_ANGULAR, resolvePackage, TEMPLATE_MANAGER, TypeScriptAstTransformer, TypeScriptUtils } from "@igniteui/cli-core";
 import { AngularTypeScriptFileUpdate } from "@igniteui/angular-templates";
 import { createCliConfig } from "../utils/cli-config";
 import { setVirtual } from "../utils/NgFileSystem";
 import { addFontsToIndexHtml, getProjects, importDefaultTheme } from "../utils/theme-import";
+import { SchematicsTemplateManager } from "../SchematicsTemplateManager";
 
 function getDependencyVersion(pkg: string, tree: Tree): string {
 	const targetFile = "/package.json";
@@ -173,6 +174,9 @@ export function addAIConfig(): Rule {
 
 export default function (): Rule {
 	return (tree: Tree) => {
+		App.initialize("angular-cli");
+		// must be initialized with physical fs first:
+		App.container.set(TEMPLATE_MANAGER, new SchematicsTemplateManager());
 		setVirtual(tree);
 		return chain([
 			importStyles(),

--- a/packages/ng-schematics/src/cli-config/index_spec.ts
+++ b/packages/ng-schematics/src/cli-config/index_spec.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 
 import { EmptyTree } from "@angular-devkit/schematics";
 import { SchematicTestRunner, UnitTestTree } from "@angular-devkit/schematics/testing";
-import { App, FEED_ANGULAR, NPM_ANGULAR, TEMPLATE_MANAGER, Util } from "@igniteui/cli-core";
+import { App, FEED_ANGULAR, NPM_ANGULAR, TEMPLATE_MANAGER } from "@igniteui/cli-core";
 import { SchematicsTemplateManager } from "../SchematicsTemplateManager";
 
 describe("cli-config schematic", () => {

--- a/packages/ng-schematics/src/cli-config/index_spec.ts
+++ b/packages/ng-schematics/src/cli-config/index_spec.ts
@@ -2,13 +2,20 @@ import * as path from "path";
 
 import { EmptyTree } from "@angular-devkit/schematics";
 import { SchematicTestRunner, UnitTestTree } from "@angular-devkit/schematics/testing";
-import { FEED_ANGULAR, NPM_ANGULAR } from "@igniteui/cli-core";
+import { App, FEED_ANGULAR, NPM_ANGULAR, TEMPLATE_MANAGER, Util } from "@igniteui/cli-core";
+import { SchematicsTemplateManager } from "../SchematicsTemplateManager";
 
 describe("cli-config schematic", () => {
 	const collectionPath = path.join(__dirname, "../collection.json");
 	const runner: SchematicTestRunner = new SchematicTestRunner("cli-schematics", collectionPath);
 	let tree: UnitTestTree;
 	const sourceRoot = "src";
+	// TODO:
+	// TS compiles export * from "./util", __createBinding defines each re-exported name as an accessor descriptor (getter-only, no setter, writable is N/A on accessor descriptors)
+	// Require the leaf module directly so spyOn works — cliCore re-exports via __createBinding getter chains
+	// (index → util/index → ai-skills), making the property non-writable at the top level.
+	// The leaf module's exports object uses plain assignments, which are writable and spyable.
+	const aiSkillsModule = require("@igniteui/cli-core/util/ai-skills");
 
 	const ngJsonConfig = {
 		projects: {
@@ -85,13 +92,12 @@ describe("cli-config schematic", () => {
 			 </body>`);
 		createIgPkgJson();
 		populatePkgJson();
+		spyOn(aiSkillsModule, "copyAISkillsToProject");
 	});
 
-	it("should create the needed files correctly", () => {
-		expect(tree).toBeTruthy();
-		expect(tree.exists("/angular.json")).toBeTruthy();
-		expect(tree.exists("/package.json")).toBeTruthy();
-		expect(tree.exists("/src/index.html"));
+	it("should set the template manager correctly", async () => {
+		await runner.runSchematic("cli-config", {}, tree);
+		expect(App.container.get(TEMPLATE_MANAGER)).toBeInstanceOf(SchematicsTemplateManager);
 	});
 
 	it("should create an ignite-ui-cli.json file correctly", async () => {
@@ -320,6 +326,11 @@ export const appConfig: ApplicationConfig = {
 			const content = JSON.parse(tree.readContent(mcpFilePath));
 			expect(content.servers["igniteui-cli"]).toEqual({ command: "npx", args: ["-y", "igniteui-cli@next", "mcp"] });
 			expect(content.servers["igniteui-theming"]).toEqual({ command: "npx", args: ["-y", "igniteui-theming", "igniteui-theming-mcp"] });
+		});
+
+		it("should call copyAISkillsToProject", async () => {
+			await runner.runSchematic("cli-config", {}, tree);
+			expect(aiSkillsModule.copyAISkillsToProject).toHaveBeenCalledTimes(1);
 		});
 
 		it("should add both servers to existing .vscode/mcp.json that has no servers", async () => {

--- a/spec/unit/ai-config-spec.ts
+++ b/spec/unit/ai-config-spec.ts
@@ -145,7 +145,7 @@ describe("Unit - ai-config command", () => {
 				if (token === FS_TOKEN) {
 					return mockFs;
 				}
-				if (token == TEMPLATE_MANAGER) {
+				if (token === TEMPLATE_MANAGER) {
 					return { getFrameworkById: () => null } as any;
 				}
 			})

--- a/spec/unit/ai-config-spec.ts
+++ b/spec/unit/ai-config-spec.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { App, Config, FS_TOKEN, GoogleAnalytics, IFileSystem, ProjectConfig, Util } from "@igniteui/cli-core";
+import { App, Config, FS_TOKEN, GoogleAnalytics, IFileSystem, ProjectConfig, TEMPLATE_MANAGER, Util } from "@igniteui/cli-core";
 import { configureMCP, configureSkills } from "../../packages/cli/lib/commands/ai-config";
 import * as aiConfig  from "../../packages/cli/lib/commands/ai-config";
 
@@ -141,7 +141,14 @@ describe("Unit - ai-config command", () => {
 				glob: jasmine.createSpy("glob").and.returnValue([])
 			} as unknown as IFileSystem;
 
-			spyOn(App.container, "get").and.returnValue(mockFs);
+			spyOn(App.container, "get").and.callFake(token => {
+				if (token === FS_TOKEN) {
+					return mockFs;
+				}
+				if (token == TEMPLATE_MANAGER) {
+					return { getFrameworkById: () => null } as any;
+				}
+			})
 			setupAngularConfig();
 
 			configureSkills();

--- a/spec/unit/ai-skills-spec.ts
+++ b/spec/unit/ai-skills-spec.ts
@@ -1,4 +1,5 @@
-import { App, Config, copyAISkillsToProject, IFileSystem, ProjectConfig, Util } from "@igniteui/cli-core";
+import * as path from "path";
+import { App, Config, copyAISkillsToProject, FS_TOKEN, IFileSystem, ProjectConfig, TEMPLATE_MANAGER, Util } from "@igniteui/cli-core";
 
 function skillsDir(pkgName: string) {
 	return `node_modules/${pkgName}/skills`;
@@ -6,6 +7,18 @@ function skillsDir(pkgName: string) {
 
 function skillFile(pkgName: string, file: string) {
 	return `${skillsDir(pkgName)}/${file}`;
+}
+
+function mockTemplateManager(templatePaths: string[]) {
+	const mockProject = { templatePaths };
+	const mockProjectLib = {
+		projectIds: ["base"],
+		getProject: jasmine.createSpy("getProject").and.returnValue(mockProject)
+	};
+	const mockTm = jasmine.createSpyObj("TemplateManager", ["getFrameworkById"]);
+	mockTm.getFrameworkById.and.returnValue({ projectLibraries: [mockProjectLib] });
+	App.container.set(TEMPLATE_MANAGER, mockTm);
+	return mockTm;
 }
 
 function makeFs(overrides: Partial<IFileSystem> = {}): IFileSystem {
@@ -326,24 +339,30 @@ describe("Unit - copyAISkillsToProject", () => {
 	});
 
 	describe("No skills available", () => {
-		it("should silently return when no skills directories are found", async () => {
+		it("should silently return when no npm skills exist and template paths also have no files", () => {
+			const FAKE_TEMPLATE_PATH = "/no-skills/template";
 			const fs = makeFs({
 				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
 					p === "ignite-ui-cli.json"
 				),
 				directoryExists: jasmine.createSpy("directoryExists").and.returnValue(false),
+				glob: jasmine.createSpy("glob").and.returnValue([]),
 				writeFile: jasmine.createSpy("writeFile")
 			});
 
-			spyOn(App.container, "get").and.returnValue(fs);
+			App.container.set(FS_TOKEN, fs);
 			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
 			spyOn(ProjectConfig, "getConfig").and.returnValue({
 				project: { framework: "angular" }
 			} as unknown as Config);
+			// Explicitly control the template fallback — glob returns nothing for the fake path too
+			const mockTm = mockTemplateManager([FAKE_TEMPLATE_PATH]);
 
-			await copyAISkillsToProject();
+			const result = copyAISkillsToProject();
 
+			expect(result.found).toBe(0);
 			expect(fs.writeFile).not.toHaveBeenCalled();
+			expect(mockTm.getFrameworkById).toHaveBeenCalledWith("angular");
 		});
 
 		it("should silently return when skills directory exists but is empty", async () => {
@@ -483,6 +502,191 @@ describe("Unit - copyAISkillsToProject", () => {
 			expect(result.skipped).toBe(0);
 			expect(result.failed).toBe(1);
 			expect(fs.writeFile).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("Template fallback (no package skills found)", () => {
+		const FAKE_TEMPLATE_PATH = "/fake/template";
+		const FAKE_SKILLS_ROOT = path.join(FAKE_TEMPLATE_PATH, "__dot__claude/skills");
+
+		it("should use angular template paths when framework is in config and no npm skills are found", () => {
+			const skillFile = path.join(FAKE_SKILLS_ROOT, "angular.md");
+			const content = "# Angular skills from template";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue(content),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === FAKE_SKILLS_ROOT
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === FAKE_SKILLS_ROOT ? [skillFile] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+			const mockTm = mockTemplateManager([FAKE_TEMPLATE_PATH]);
+
+			copyAISkillsToProject();
+
+			expect(mockTm.getFrameworkById).toHaveBeenCalledWith("angular");
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/angular.md", content);
+		});
+
+		it("should detect react from package.json and use react template paths when no npm skills are found", () => {
+			const skillFile = path.join(FAKE_SKILLS_ROOT, "react.md");
+			const content = "# React skills from template";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "./package.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.callFake((p: string) => {
+					if (p === "./package.json") return JSON.stringify({ dependencies: { "react": "^19.0.0" } });
+					return content;
+				}),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === FAKE_SKILLS_ROOT
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === FAKE_SKILLS_ROOT ? [skillFile] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+			const mockTm = mockTemplateManager([FAKE_TEMPLATE_PATH]);
+
+			copyAISkillsToProject();
+
+			expect(mockTm.getFrameworkById).toHaveBeenCalledWith("react");
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/react.md", content);
+		});
+
+		it("should use webcomponents (catch-all) template paths when no angular or react detected in package.json", () => {
+			const skillFile = path.join(FAKE_SKILLS_ROOT, "webcomponents.md");
+			const content = "# WC skills from template";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "./package.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.callFake((p: string) => {
+					if (p === "./package.json") return JSON.stringify({ dependencies: { "lit": "^3.0.0" } });
+					return content;
+				}),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === FAKE_SKILLS_ROOT
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === FAKE_SKILLS_ROOT ? [skillFile] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+			const mockTm = mockTemplateManager([FAKE_TEMPLATE_PATH]);
+
+			copyAISkillsToProject();
+
+			expect(mockTm.getFrameworkById).toHaveBeenCalledWith("webcomponents");
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/webcomponents.md", content);
+		});
+
+		it("should return empty result when no package.json exists and no npm skills are found", () => {
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.returnValue(false),
+				directoryExists: jasmine.createSpy("directoryExists").and.returnValue(false),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(false);
+			// no package.json → detectFrameworkFromPackageJson returns null → no template fallback
+
+			const result = copyAISkillsToProject();
+
+			expect(result.found).toBe(0);
+			expect(result.skipped).toBe(0);
+			expect(result.failed).toBe(0);
+			expect(fs.writeFile).not.toHaveBeenCalled();
+		});
+
+		it("should preserve nested directory structure from template skill paths", () => {
+			const nestedFile = path.join(FAKE_SKILLS_ROOT, "grids", "grid.md");
+			const content = "# Grid skills from template";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+					p === "ignite-ui-cli.json"
+				),
+				readFile: jasmine.createSpy("readFile").and.returnValue(content),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === FAKE_SKILLS_ROOT
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === FAKE_SKILLS_ROOT ? [nestedFile] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "angular" }
+			} as unknown as Config);
+			mockTemplateManager([FAKE_TEMPLATE_PATH]);
+
+			copyAISkillsToProject();
+
+			expect(fs.writeFile).toHaveBeenCalledWith(".claude/skills/grids/grid.md", content);
+		});
+
+		it("should use config framework (not detectFrameworkFromPackageJson) when config has framework but npm skills absent", () => {
+			// framework from config = "react"; package.json has @angular/core — config must win
+			const skillFile = path.join(FAKE_SKILLS_ROOT, "react.md");
+			const content = "# React skills from template";
+
+			const fs = makeFs({
+				fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) => {
+					if (p === "ignite-ui-cli.json") return true;
+					if (p === "./package.json") return true;
+					return false;
+				}),
+				readFile: jasmine.createSpy("readFile").and.callFake((p: string) => {
+					if (p === "./package.json") return JSON.stringify({ dependencies: { "@angular/core": "^17.0.0" } });
+					return content;
+				}),
+				directoryExists: jasmine.createSpy("directoryExists").and.callFake((p: string) =>
+					p === FAKE_SKILLS_ROOT
+				),
+				glob: jasmine.createSpy("glob").and.callFake((dir: string) =>
+					dir === FAKE_SKILLS_ROOT ? [skillFile] : []
+				),
+				writeFile: jasmine.createSpy("writeFile")
+			});
+
+			App.container.set(FS_TOKEN, fs);
+			spyOn(ProjectConfig, "hasLocalConfig").and.returnValue(true);
+			spyOn(ProjectConfig, "getConfig").and.returnValue({
+				project: { framework: "react" } // config says react, even though package.json has angular
+			} as unknown as Config);
+			const mockTm = mockTemplateManager([FAKE_TEMPLATE_PATH]);
+
+			copyAISkillsToProject();
+
+			// ??= must NOT overwrite already-set framework value
+			expect(mockTm.getFrameworkById).toHaveBeenCalledWith("react");
+			expect(mockTm.getFrameworkById).not.toHaveBeenCalledWith("angular");
 		});
 	});
 

--- a/spec/unit/detect-framework-spec.ts
+++ b/spec/unit/detect-framework-spec.ts
@@ -1,0 +1,99 @@
+import { App, IFileSystem } from "@igniteui/cli-core";
+import { detectFrameworkFromPackageJson } from "../../packages/core/util/detect-framework";
+
+function makeFs(pkgJson?: object): IFileSystem {
+	const present = pkgJson !== undefined;
+	return {
+		fileExists: jasmine.createSpy("fileExists").and.callFake((p: string) =>
+			p === "./package.json" && present
+		),
+		readFile: jasmine.createSpy("readFile").and.returnValue(JSON.stringify(pkgJson ?? {})),
+		writeFile: jasmine.createSpy("writeFile"),
+		directoryExists: jasmine.createSpy("directoryExists").and.returnValue(false),
+		glob: jasmine.createSpy("glob").and.returnValue([]),
+	} as unknown as IFileSystem;
+}
+
+describe("Unit - detectFrameworkFromPackageJson", () => {
+	it("returns null when package.json is absent", () => {
+		spyOn(App.container, "get").and.returnValue(makeFs());
+		expect(detectFrameworkFromPackageJson()).toBeNull();
+	});
+
+	it("returns null when package.json is malformed JSON", () => {
+		const fs = makeFs({});
+		(fs.fileExists as jasmine.Spy).and.returnValue(true);
+		(fs.readFile as jasmine.Spy).and.returnValue("not-valid-json{{{");
+		spyOn(App.container, "get").and.returnValue(fs);
+		expect(detectFrameworkFromPackageJson()).toBeNull();
+	});
+
+	describe("Angular detection", () => {
+		it("detects angular when @angular/core is in dependencies", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "@angular/core": "^17.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("angular");
+		});
+
+		it("detects angular when @angular/core is in devDependencies", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ devDependencies: { "@angular/core": "^17.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("angular");
+		});
+	});
+
+	describe("React detection", () => {
+		it("detects react when react is in dependencies", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "react": "^19.0.0", "react-dom": "^19.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("react");
+		});
+
+		it("detects react when react is in devDependencies", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ devDependencies: { "react": "^19.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("react");
+		});
+	});
+
+	describe("WebComponents / plain-JS fallback", () => {
+		it("returns webcomponents for an empty package.json (no known framework)", () => {
+			spyOn(App.container, "get").and.returnValue(makeFs({}));
+			expect(detectFrameworkFromPackageJson()).toBe("webcomponents");
+		});
+
+		it("returns webcomponents when only unrelated packages are present", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "lit": "^3.0.0", "vite": "^6.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("webcomponents");
+		});
+
+		it("returns webcomponents when lit is present but no react or angular", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "lit": "^3.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("webcomponents");
+		});
+	});
+
+	describe("Priority", () => {
+		it("prefers angular over react when both are present", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "@angular/core": "^17.0.0", "react": "^19.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("angular");
+		});
+
+		it("prefers react over webcomponents fallback when react is present", () => {
+			spyOn(App.container, "get").and.returnValue(
+				makeFs({ dependencies: { "react": "^19.0.0", "lit": "^3.0.0" } })
+			);
+			expect(detectFrameworkFromPackageJson()).toBe("react");
+		});
+	});
+});


### PR DESCRIPTION
## Description

Use project templates (with additional framework detection in case there's no CLI config in project) to provide skills when calling `ai-config`. Installed packages in deps (if available) still take precedence.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [x] `igniteui-cli` (packages/cli)
- [x] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [x] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [x] I have tested my changes locally (`npm run test`)
- [x] I have built the project successfully (`npm run build`)
- [x] I have run the linter (`npm run lint`)
- [x] I have added/updated tests as needed
- [x] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
