### PR TITLE
fix: Hide base project from avalible projects

### DIFF
--- a/packages/cli/lib/templates/IgniteUIForReactTemplate.ts
+++ b/packages/cli/lib/templates/IgniteUIForReactTemplate.ts
@@ -27,6 +27,7 @@ export class IgniteUIForReactTemplate implements Template {
 	public framework: string = "react";
 	public projectType: string;
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 	public packages = [];
 	public delimiters = defaultDelimiters;
 	// non-standard template prop

--- a/packages/cli/lib/templates/IgniteUIForWebComponentsTemplate.ts
+++ b/packages/cli/lib/templates/IgniteUIForWebComponentsTemplate.ts
@@ -16,6 +16,7 @@ export class IgniteUIForWebComponentsTemplate implements Template {
 	public framework: string = "webcomponents";
 	public projectType = "igc-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 	public packages = [];
 	public dependencies: TemplateDependency[] = [];
 	public delimiters = defaultDelimiters;

--- a/packages/cli/lib/templates/jQueryTemplate.ts
+++ b/packages/cli/lib/templates/jQueryTemplate.ts
@@ -17,6 +17,7 @@ export class jQueryTemplate implements Template {
 	public framework: string = "jquery";
 	public projectType: string;
 	public hasExtraConfiguration: boolean;
+	public isHidden: boolean = false;
 	public packages = [];
 	public delimiters = defaultDelimiters;
 

--- a/packages/cli/templates/jquery/js/projects/empty/index.ts
+++ b/packages/cli/templates/jquery/js/projects/empty/index.ts
@@ -10,6 +10,7 @@ class EmptyProject implements ProjectTemplate {
 	public framework: string = "jquery";
 	public projectType: string = "js";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 	public routesFile = "bs-routes.json";
 	public delimiters = defaultDelimiters;
 

--- a/packages/cli/templates/react/igr-ts/projects/_base/index.ts
+++ b/packages/cli/templates/react/igr-ts/projects/_base/index.ts
@@ -9,6 +9,7 @@ export class BaseIgrTsProject implements ProjectTemplate {
 	public projectType: string = "tsx";
 	public dependencies: string[];
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = true;
 	public delimiters = defaultDelimiters;
 
 	public get templatePaths(): string[] {

--- a/packages/cli/templates/react/igr-ts/projects/_base_with_home/index.ts
+++ b/packages/cli/templates/react/igr-ts/projects/_base_with_home/index.ts
@@ -10,6 +10,7 @@ export class BaseWithHomeIgrTsProject extends BaseIgrTsProject implements Projec
 	public framework: string = "react";
 	public projectType: string = "igr-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = true;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/react/igr-ts/projects/base/index.ts
+++ b/packages/cli/templates/react/igr-ts/projects/base/index.ts
@@ -10,6 +10,7 @@ export class BasePageIgrTsProject extends BaseIgrTsProject implements ProjectTem
 	public framework: string = "react";
 	public projectType: string = "igr-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = true;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/react/igr-ts/projects/empty/index.ts
+++ b/packages/cli/templates/react/igr-ts/projects/empty/index.ts
@@ -10,6 +10,7 @@ export class EmptyIgrTsProject extends BaseWithHomeIgrTsProject implements Proje
 	public framework: string = "react";
 	public projectType: string = "igr-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/react/igr-ts/projects/top-nav/index.ts
+++ b/packages/cli/templates/react/igr-ts/projects/top-nav/index.ts
@@ -10,6 +10,7 @@ export class TopNavIgrTsProject extends BaseWithHomeIgrTsProject implements Proj
 	public framework: string = "react";
 	public projectType: string = "igr-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base/index.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base/index.ts
@@ -9,6 +9,7 @@ export class BaseIgcProject implements ProjectTemplate {
 	public framework: string = "webcomponents";
 	public projectType: string = "igc-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = true;
 	public delimiters = defaultDelimiters;
 
 	public get templatePaths(): string[] {

--- a/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/index.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/_base_with_home/index.ts
@@ -6,6 +6,7 @@ export class BaseWithHomeIgcProject extends BaseIgcProject implements ProjectTem
 	public id: string = "base with home";
 	public name = "Base With Home";
 	public description = "Empty project layout structure for Ignite UI for Web Components";
+	public isHidden: boolean = true;
 
 	public get templatePaths() {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/webcomponents/igc-ts/projects/base/index.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/base/index.ts
@@ -10,6 +10,7 @@ export class BasePageTemplate extends BaseIgcProject implements ProjectTemplate 
 	public projectType: string = "igc-ts";
 	public dependencies: string[];
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = true;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/webcomponents/igc-ts/projects/empty/index.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/empty/index.ts
@@ -10,6 +10,7 @@ export class EmptyPageTemplate extends BaseWithHomeIgcProject implements Project
 	public projectType: string = "igc-ts";
 	public dependencies: string[];
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/cli/templates/webcomponents/igc-ts/projects/side-nav/index.ts
+++ b/packages/cli/templates/webcomponents/igc-ts/projects/side-nav/index.ts
@@ -10,6 +10,7 @@ export class SideNavProject extends BaseWithHomeIgcProject implements ProjectTem
 	public projectType: string = "igc-ts";
 	public dependencies: string[];
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths() {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/core/prompt/BasePromptSession.ts
+++ b/packages/core/prompt/BasePromptSession.ts
@@ -222,13 +222,14 @@ export abstract class BasePromptSession {
 	 * @param projectLibrary to get theme for
 	 */
 	protected async getProjectTemplate(projectLibrary: ProjectLibrary): Promise<ProjectTemplate> {
+		const visibleProjects = projectLibrary.projects.filter(p => !p.isHidden);
 		const componentNameRes = await this.getUserInput({
 			type: "list",
 			name: "projTemplate",
 			message: "Choose project template:",
-			choices: Util.formatChoices(projectLibrary.projects)
+			choices: Util.formatChoices(visibleProjects)
 		});
-		return projectLibrary.projects.find(x => x.name === componentNameRes);
+		return visibleProjects.find(x => x.name === componentNameRes);
 	}
 
 	/**

--- a/packages/core/types/BaseTemplate.ts
+++ b/packages/core/types/BaseTemplate.ts
@@ -26,6 +26,9 @@ export interface BaseTemplate {
 
 	/** This property controls if extra configuration is available to the template */
 	hasExtraConfiguration: boolean;
+
+	/** Controls if the template should be hidden from listings and prompts */
+	isHidden: boolean;
 	/** An array with the physical path to the template files */
 	templatePaths: string[];
 

--- a/packages/core/types/BaseTemplate.ts
+++ b/packages/core/types/BaseTemplate.ts
@@ -28,7 +28,7 @@ export interface BaseTemplate {
 	hasExtraConfiguration: boolean;
 
 	/** Controls if the template should be hidden from listings and prompts */
-	isHidden: boolean;
+	isHidden?: boolean;
 	/** An array with the physical path to the template files */
 	templatePaths: string[];
 

--- a/packages/igx-templates/IgniteUIForAngularTemplate.ts
+++ b/packages/igx-templates/IgniteUIForAngularTemplate.ts
@@ -18,6 +18,7 @@ export class IgniteUIForAngularTemplate implements Template {
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration: boolean = false;
+	public isHidden: boolean = false;
 	public packages: string[] = [];
 
 	public dependencies: TemplateDependency[] = [];

--- a/packages/igx-templates/igx-ts/projects/_base/index.ts
+++ b/packages/igx-templates/igx-ts/projects/_base/index.ts
@@ -9,6 +9,7 @@ export class BaseIgxProject implements ProjectTemplate {
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration = false;
+	public isHidden: boolean = true;
 	public delimiters = {
 		content: {
 			end: `%>`,

--- a/packages/igx-templates/igx-ts/projects/_base_with_home/index.ts
+++ b/packages/igx-templates/igx-ts/projects/_base_with_home/index.ts
@@ -10,6 +10,7 @@ export class BaseWithHomeProject extends BaseIgxProject implements ProjectTempla
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration = false;
+	public isHidden: boolean = true;
 
 	public get templatePaths() {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/igx-templates/igx-ts/projects/base/index.ts
+++ b/packages/igx-templates/igx-ts/projects/base/index.ts
@@ -10,6 +10,7 @@ export class BasePageTemplate extends BaseIgxProject implements ProjectTemplate 
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration = false;
+	public isHidden: boolean = true;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/igx-templates/igx-ts/projects/empty/index.ts
+++ b/packages/igx-templates/igx-ts/projects/empty/index.ts
@@ -10,6 +10,7 @@ export class EmptyPageTemplate extends BaseWithHomeProject implements ProjectTem
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths(): string[] {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/igx-templates/igx-ts/projects/side-nav/index.ts
+++ b/packages/igx-templates/igx-ts/projects/side-nav/index.ts
@@ -10,6 +10,7 @@ export class SideNavProject extends BaseWithHomeProject implements ProjectTempla
 	public framework: string = "angular";
 	public projectType: string = "igx-ts";
 	public hasExtraConfiguration = false;
+	public isHidden: boolean = false;
 
 	public get templatePaths() {
 		return [...super.templatePaths, path.join(__dirname, "files")];

--- a/packages/ng-schematics/src/component/index_spec.ts
+++ b/packages/ng-schematics/src/component/index_spec.ts
@@ -32,6 +32,7 @@ describe("component",  () => {
 			framework: "angular",
 			projectType: "ts",
 			hasExtraConfiguration: true,
+			isHidden: false,
 			templatePaths: ["/path/to/template"],
 			generateConfig: jasmine.createSpy().and.returnValue({}),
 			getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/packages/ng-schematics/src/ng-new/index_spec.ts
+++ b/packages/ng-schematics/src/ng-new/index_spec.ts
@@ -33,6 +33,7 @@ describe("Schematics ng-new", () => {
 			framework: "angular",
 			projectType: "ts",
 			hasExtraConfiguration: true,
+			isHidden: false,
 			templatePaths: ["/path/to/template"],
 			generateConfig: jasmine.createSpy().and.returnValue({}),
 			getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/packages/ng-schematics/src/upgrade-packages/index.spec.ts
+++ b/packages/ng-schematics/src/upgrade-packages/index.spec.ts
@@ -43,6 +43,7 @@ describe("Schematics upgrade-packages", () => {
 			framework: "angular",
 			projectType: "ts",
 			hasExtraConfiguration: true,
+			isHidden: false,
 			templatePaths: ["/path/to/template"],
 			generateConfig: jasmine.createSpy().and.returnValue({}),
 			getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/spec/unit/PromptSession-spec.ts
+++ b/spec/unit/PromptSession-spec.ts
@@ -22,6 +22,7 @@ function createMockBaseTemplate(): BaseTemplate {
 		framework: "angular",
 		projectType: "ts",
 		hasExtraConfiguration: true,
+		isHidden: false,
 		templatePaths: ["/path/to/template"],
 		generateConfig: jasmine.createSpy().and.returnValue({}),
 		getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/spec/unit/PromptSession-spec.ts
+++ b/spec/unit/PromptSession-spec.ts
@@ -865,4 +865,31 @@ describe("Unit - PromptSession", () => {
 		const expectedCall = DEFAULT_THEME.replace(/\s/g, "");
 		expect(actualCall).toEqual(expectedCall);
 	});
+	it("getProjectTemplate - should exclude isHidden templates from choices and resolve the selected visible one", async () => {
+		const mockBaseTemplate = createMockBaseTemplate();
+		const hiddenProject = createMockProjectTemplate({ ...mockBaseTemplate, name: "base", isHidden: true });
+		const visibleProject1 = createMockProjectTemplate({ ...mockBaseTemplate, name: "empty", isHidden: false });
+		const visibleProject2 = createMockProjectTemplate({ ...mockBaseTemplate, name: "top-nav", isHidden: false });
+		const mockProjectLibrary = {
+			projects: [hiddenProject, visibleProject1, visibleProject2]
+		} as unknown as ProjectLibrary;
+
+		const mockTemplate = jasmine.createSpyObj("mockTemplate", ["getProjectLibrary"]);
+		const mockSession = new PromptSession(mockTemplate);
+
+		spyOn(InquirerWrapper, "select").and.returnValue(Promise.resolve("empty"));
+
+		const result = await (mockSession as any).getProjectTemplate(mockProjectLibrary);
+
+		// Only the visible projects should appear as choices
+		expect(InquirerWrapper.select).toHaveBeenCalledTimes(1);
+		const selectCall = (InquirerWrapper.select as jasmine.Spy).calls.mostRecent();
+		const choiceValues: string[] = selectCall.args[0].choices.map((c: { value: string }) => c.value);
+		expect(choiceValues).not.toContain("base");
+		expect(choiceValues).toContain("empty");
+		expect(choiceValues).toContain("top-nav");
+
+		// The resolved template should be the selected visible project
+		expect(result).toBe(visibleProject1);
+	});
 });

--- a/spec/unit/add-spec.ts
+++ b/spec/unit/add-spec.ts
@@ -21,6 +21,7 @@ function createMockBaseTemplate(): BaseTemplate {
 		framework: "angular",
 		projectType: "ts",
 		hasExtraConfiguration: true,
+		isHidden: false,
 		templatePaths: ["/path/to/template"],
 		generateConfig: jasmine.createSpy().and.returnValue({}),
 		getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/spec/unit/new-spec.ts
+++ b/spec/unit/new-spec.ts
@@ -17,6 +17,7 @@ function createMockBaseTemplate(): BaseTemplate {
 		framework: "angular",
 		projectType: "ts",
 		hasExtraConfiguration: true,
+		isHidden: false,
 		templatePaths: ["/path/to/template"],
 		generateConfig: null,
 		getExtraConfiguration: jasmine.createSpy().and.returnValue([]),

--- a/spec/unit/upgrade-spec.ts
+++ b/spec/unit/upgrade-spec.ts
@@ -39,6 +39,7 @@ describe("Unit - Upgrade command", () => {
 			framework: "angular",
 			projectType: "ts",
 			hasExtraConfiguration: true,
+			isHidden: false,
 			templatePaths: ["/path/to/template"],
 			generateConfig: jasmine.createSpy().and.returnValue({}),
 			getExtraConfiguration: jasmine.createSpy().and.returnValue([]),


### PR DESCRIPTION
## Description

Introduces a new `isHidden` boolean on `BaseTemplate` so that project templates can be excluded from the interactive wizard while still being generatable when referenced explicitly by ID.

- Added `isHidden: boolean` to the `BaseTemplate` interface (`packages/core/types/BaseTemplate.ts`) and declared it on every implementing class (`jQueryTemplate`, `IgniteUIForReactTemplate`, `IgniteUIForWebComponentsTemplate`, `IgniteUIForAngularTemplate`, and the project `_base` classes).
- Set `isHidden: true` on the `_base`, `_base_with_home`, and `base` project templates for all three framework libraries (React, Web Components, Angular).
- Added explicit `isHidden: false` on the visible descendants (`empty`, `top-nav`, `side-nav`) to prevent them from inheriting `true` from `_base_with_home`. `side-nav-auth` inherits `false` from `side-nav` and did not need to change.
- `BasePromptSession.getProjectTemplate` now filters `projectLibrary.projects` by `!p.isHidden` before presenting the choice list, so hidden templates no longer appear in the step-by-step wizard.
- CLI behaviour via `ig new --template <id>` is unchanged — `projectLib.getProject(id)` resolves by folder name and does not consult `isHidden`, so hidden templates can still be scaffolded when requested explicitly.
- `ig new --help` is unaffected because `--template` is a free-form string option with no enumerated choices.
- Updated all affected test mocks (`spec/unit/*`, `packages/ng-schematics/src/**/*spec*.ts`) to satisfy the new required interface property.

## Related Issue

Closes #1575 #1600 
## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [x] `igniteui-cli` (packages/cli)
- [x] `@igniteui/cli-core` (packages/core)
- [x] `@igniteui/angular-templates` (packages/igx-templates)
- [x] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [x] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [x] My changes do not introduce new warnings or errors

## Additional Context

Verification steps:

```bash
# hidden template still works when passed explicitly
node packages/cli/bin/execute.js new foo-base -f react -t igr-ts --template base --skip-install --skip-git

# wizard: "Choose project template" list should contain only `empty` and `top-nav` (React),
# `empty` and `side-nav` (Web Components / Angular) — `base` should no longer be listed
node packages/cli/bin/execute.js
```

Inheritance note: because `_base_with_home` extends `_base` and the visible `empty`/`top-nav`/`side-nav` classes extend `_base_with_home`, setting `isHidden` on the bases alone would have cascaded `true` onto the visible variants. The visible descendants therefore explicitly override `isHidden = false`.
