### PR TITLE
Fix [MCP] Enforce library boundaries in search_api and server instructions

### DIFF
--- a/packages/igniteui-mcp/igniteui-doc-mcp/src/index.ts
+++ b/packages/igniteui-mcp/igniteui-doc-mcp/src/index.ts
@@ -70,7 +70,10 @@ const server = new McpServer(
       "React → Igr prefix (IgrGrid), package 'igniteui-react', .tsx files. " +
       "Blazor → Igb prefix (IgbGrid), package 'IgniteUI.Blazor', .razor files. " +
       "Web Components → Igc prefix + Component suffix (IgcGridComponent), package 'igniteui-webcomponents', .ts+.html with custom elements. " +
-      "If the framework is unclear from context, ask the user.",
+      "If the framework is unclear from context, ask the user. " +
+      "LIBRARY BOUNDARY RULE: Once the target framework is identified, always pass it as the 'framework' or 'platform' parameter to every tool call. " +
+      "Never apply component APIs, event names, binding syntax, prop names, or state patterns from one framework to code in another framework. " +
+      "Angular (Igx), React (Igr), Blazor (Igb), and Web Components (Igc) each have distinct APIs — they are not interchangeable.",
   }
 );
 

--- a/packages/igniteui-mcp/igniteui-doc-mcp/src/tools/constants.ts
+++ b/packages/igniteui-mcp/igniteui-doc-mcp/src/tools/constants.ts
@@ -63,7 +63,7 @@ Use this as the discovery step when the exact component name is unknown — e.g.
 
 Each result includes: exact component name, framework tag, API type (class/interface/directive/enum), match count, keyword list, and a content excerpt. Pass the component name and framework from a result to get_api_reference for full details. To reduce response size, use section="properties", "methods", or "events" instead of the default "all".
 
-Omit framework to search all frameworks at once. Maximum query length is 256 characters.
+Always specify \`platform\` when your target framework is known — this prevents cross-framework API contamination. Omit only when you explicitly need to compare or search across all frameworks at once. Maximum query length is 256 characters.
 `
 };
 
@@ -131,6 +131,15 @@ Most tools require a \`framework\` parameter. Determine the framework from the u
 3. **File extensions** — .razor → blazor, .tsx → react
 4. **User's explicit statement** — "I'm using Angular", "Blazor project", etc.
 5. **Ask the user** if none of the above apply
+
+## Library Boundary Rules
+
+> **These rules are mandatory. Violating them produces code that looks valid but fails at runtime.**
+
+- **Always pass \`framework\` / \`platform\` to every tool call once the target framework is known.** Do not omit it.
+- **Never mix APIs across frameworks.** Angular (\`Igx\`), React (\`Igr\`), Blazor (\`Igb\`), and Web Components (\`Igc\`) each have distinct component names, event shapes, prop names, binding syntax, and state models. They are not interchangeable.
+- **Do not apply Angular patterns to React code** (or any other cross-framework combination). For example: Angular template bindings (\`(cellEditDone)\`), directive imports (\`IGX_GRID_DIRECTIVES\`), and signal-based \`viewChild\` are Angular-only. React uses callback props, hook-based state, and \`useRef\`.
+- **When \`search_api\` returns results from multiple frameworks, only use entries that match your target framework.**
 
 ## Documentation Tools
 

--- a/packages/igniteui-mcp/igniteui-doc-mcp/src/tools/handlers.ts
+++ b/packages/igniteui-mcp/igniteui-doc-mcp/src/tools/handlers.ts
@@ -85,6 +85,11 @@ export function createSearchApiHandler(docLoader: ApiDocLoader) {
       return `**${h.entry.component}** ${platformTag} ${typeTag} (${h.matches} matches)${kwTag}\n${h.excerpt}`;
     });
 
-    return { content: [{ type: "text", text: lines.join("\n\n") }] };
+    const frameworks = new Set(hits.map(h => h.entry.platform));
+    const crossPlatformWarning = !platform && frameworks.size > 1
+      ? `⚠ Results span multiple frameworks (${[...frameworks].join(', ')}). Only use entries that match your target framework — never apply APIs, events, or binding syntax from one framework to another.\n\n`
+      : '';
+
+    return { content: [{ type: "text", text: crossPlatformWarning + lines.join("\n\n") }] };
   };
 }


### PR DESCRIPTION
Closes #1620

## Problem

When `search_api` is called without a `platform` argument, it returns results interleaved across all four frameworks (Angular, React, Blazor, Web Components) with no warning. An AI consuming those results could pick up Angular-specific event names, directive imports, or binding syntax and apply them to React or Blazor code — producing output that looks valid at first glance but fails at runtime.

Additionally, the MCP server's `instructions` field and the `USAGE_GUIDE` prompt only described how to *detect* the target framework, but never stated that once identified its APIs must be used exclusively. This left a gap that allowed cross-library API patterns to bleed into generated code.

## Changes

- **`src/index.ts`** — Extended `server.instructions` with an explicit **LIBRARY BOUNDARY RULE**: once the target framework is identified, always pass it as `framework`/`platform` to every tool call, and never apply APIs, events, binding syntax, or state patterns from one framework to another.

- **`src/tools/constants.ts`**
  - Added a **"Library Boundary Rules"** section to `USAGE_GUIDE` that explicitly calls out the incompatibility of Igx/Igr/Igb/Igc APIs and mandates always passing `platform`.
  - Updated the `search_api` tool description to prefer passing `platform` when the target framework is known, instead of encouraging omission.

- **`src/tools/handlers.ts`** — When `search_api` is called without `platform` and the results span more than one framework, the response now prepends a warning: _"⚠ Results span multiple frameworks. Only use entries that match your target framework — never apply APIs, events, or binding syntax from one framework to another."_
