### PR TITLE
chore: versionScript to use consistent dependency range prefix

### DIFF
--- a/scripts/versionScript.ts
+++ b/scripts/versionScript.ts
@@ -4,14 +4,18 @@ import * as path from "path";
 import { generateChangelog } from "./changelogScript";
 
 let version: string;
+let coreVersion: string;
 const packageFolders = ["cli", "core", "igx-templates", "ng-schematics", "igniteui-mcp/igniteui-doc-mcp"];
 const updatedPackages = ["@igniteui/angular-templates", "@igniteui/angular-schematics"];
+const coreVersionedPackages = ["@igniteui/cli-core", "@igniteui/mcp-server"];
+const DEP_RANGE_PREFIX = "~";
 
 function getVersion() {
 	const igxPackageJson = JSON.parse(readFileSync("packages/igx-templates/igx-ts/projects/_base/files/package.json", "utf-8"));
 	const versionIG = igxPackageJson.dependencies["igniteui-angular"].replace(/^[^0-9]+/, "");
 	const majorMinor = versionIG.split(".").slice(0, 2).join(".");
 	const versionCLI = JSON.parse(readFileSync("packages/core/package.json").toString());
+	coreVersion = versionCLI.version;
 	let patch = versionCLI.version;
 	if (patch.indexOf("-") > -1) {
 		const prerelease = patch.split("-");
@@ -30,8 +34,12 @@ function updatePackageJson(fileLocation: string) {
 	}
 	for (const pkg of updatedPackages) {
 		if (pkgJson.dependencies[pkg]) {
-			const prefix = pkgJson.dependencies[pkg].match(/[~\^]/g);
-			pkgJson.dependencies[pkg] = `${prefix ? prefix[0] : ""}${version}`;
+			pkgJson.dependencies[pkg] = `${DEP_RANGE_PREFIX}${version}`;
+		}
+	}
+	for (const pkg of coreVersionedPackages) {
+		if (pkgJson.dependencies?.[pkg]) {
+			pkgJson.dependencies[pkg] = `${DEP_RANGE_PREFIX}${coreVersion}`;
 		}
 	}
 	writeFileSync(fileLocation, JSON.stringify(pkgJson, null, 2) + "\n");


### PR DESCRIPTION
Enforce version range for cross-package deps so the release script per https://github.com/IgniteUI/igniteui-cli/wiki/publishing-new-versions#prepare-local-state produces the expected result instead of having to manually adjust those after.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [x] Build / CI configuration change

## Affected Packages

- [ ] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [ ] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [ ] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [ ] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
