### PR TITLE
fix: ignore submodules in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,12 @@ export default [
       'packages/igniteui-mcp/igniteui-doc-mcp/src/__tests__/**/*',
       'packages/igniteui-mcp/igniteui-doc-mcp/scripts/**/*',
       'packages/igniteui-mcp/igniteui-doc-mcp/vitest.config.ts',
+      // Git submodules — separate repos, not part of this project's tsconfigs.
+      'packages/igniteui-mcp/igniteui-doc-mcp/angular/**/*',
+      'packages/igniteui-mcp/igniteui-doc-mcp/react/**/*',
+      'packages/igniteui-mcp/igniteui-doc-mcp/webcomponents/**/*',
+      'packages/igniteui-mcp/igniteui-doc-mcp/blazor/**/*',
+      'packages/igniteui-mcp/igniteui-doc-mcp/common/**/*',
     ]
   },
 ];


### PR DESCRIPTION
## Description

<!-- Provide a clear summary of the changes and the motivation behind them. -->

## Related Issue

Closes #<issue-number>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Build / CI configuration change

## Affected Packages

- [ ] `igniteui-cli` (packages/cli)
- [ ] `@igniteui/cli-core` (packages/core)
- [ ] `@igniteui/angular-templates` (packages/igx-templates)
- [ ] `@igniteui/angular-schematics` (packages/ng-schematics)
- [ ] `@igniteui/mcp-server` (packages/igniteui-mcp)

## Checklist

- [ ] I have tested my changes locally (`npm run test`)
- [ ] I have built the project successfully (`npm run build`)
- [ ] I have run the linter (`npm run lint`)
- [ ] I have added/updated tests as needed
- [ ] My changes do not introduce new warnings or errors

## Additional Context

<!-- Add any screenshots, sample output, or other context about the pull request. -->
